### PR TITLE
feat(scanner): detect present-but-ineffective header values

### DIFF
--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -124,11 +124,43 @@ func (ReferrerPolicyChecker) Check(headers http.Header) []Finding {
 // referrerPolicyWeakness flags unsafe-url, which explicitly sends the full
 // URL (including any query string) to third parties on every cross-origin
 // request — the opposite of what this header is for.
+//
+// A single Referrer-Policy value may be a comma-separated fallback list
+// (e.g. "strict-origin-when-cross-origin, unsafe-url"), and per the
+// Referrer Policy spec the browser applies the last *recognized* token in
+// that list, not the value as a whole — so a strong-looking value can still
+// resolve to unsafe-url if a weaker token follows it.
 func referrerPolicyWeakness(value string) (weak bool, message string) {
-	if strings.EqualFold(strings.TrimSpace(value), "unsafe-url") {
+	if strings.EqualFold(effectiveReferrerPolicy(value), "unsafe-url") {
 		return true, "unsafe-url leaks the full URL, including query strings, to third parties on cross-origin requests"
 	}
 	return false, ""
+}
+
+var knownReferrerPolicies = map[string]bool{
+	"no-referrer":                     true,
+	"no-referrer-when-downgrade":      true,
+	"origin":                          true,
+	"origin-when-cross-origin":        true,
+	"same-origin":                     true,
+	"strict-origin":                   true,
+	"strict-origin-when-cross-origin": true,
+	"unsafe-url":                      true,
+}
+
+// effectiveReferrerPolicy returns the token a browser would actually apply
+// from a (possibly comma-separated) Referrer-Policy value: later recognized
+// tokens override earlier ones, and unrecognized tokens are skipped rather
+// than treated as the effective policy.
+func effectiveReferrerPolicy(value string) string {
+	effective := ""
+	for _, token := range strings.Split(value, ",") {
+		token = strings.TrimSpace(token)
+		if knownReferrerPolicies[strings.ToLower(token)] {
+			effective = token
+		}
+	}
+	return effective
 }
 
 func checkPresence(headers http.Header, name string, severity Severity, reference string) []Finding {
@@ -151,16 +183,24 @@ func checkPresence(headers http.Header, name string, severity Severity, referenc
 //
 // A misconfigured proxy or CDN can cause a header to appear more than once
 // in the same response; headers.Get only ever sees the first of those. We
-// validate every occurrence and flag the finding as soon as any one of them
-// is weak, rather than letting send order decide whether the scan reports
-// pass or weak.
+// validate every non-blank occurrence and flag the finding as soon as any
+// one of them is weak, rather than letting send order decide whether the
+// scan reports pass or weak. A blank occurrence (e.g. a stray empty
+// duplicate appended by some infra) is skipped rather than validated: it
+// carries no value of its own to judge, and treating "" as a value would
+// let it masquerade as a weak one, downgrading an otherwise strong header
+// on the strength of infra noise.
 func checkValue(headers http.Header, name string, severity Severity, reference string, validate func(value string) (weak bool, message string)) []Finding {
 	findings := checkPresence(headers, name, severity, reference)
 	if findings[0].Status != StatusPass {
 		return findings
 	}
 	for _, value := range headers.Values(name) {
-		if weak, message := validate(strings.TrimSpace(value)); weak {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if weak, message := validate(value); weak {
 			findings[0].Status = StatusWeak
 			findings[0].Message = message
 			break

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -148,14 +148,23 @@ func checkPresence(headers http.Header, name string, severity Severity, referenc
 // present value can still be a functional no-op. Only a Finding that's
 // already StatusPass gets validated — missing/empty values stay StatusMissing,
 // since "provides no protection" and "isn't set" are different findings.
+//
+// A misconfigured proxy or CDN can cause a header to appear more than once
+// in the same response; headers.Get only ever sees the first of those. We
+// validate every occurrence and flag the finding as soon as any one of them
+// is weak, rather than letting send order decide whether the scan reports
+// pass or weak.
 func checkValue(headers http.Header, name string, severity Severity, reference string, validate func(value string) (weak bool, message string)) []Finding {
 	findings := checkPresence(headers, name, severity, reference)
 	if findings[0].Status != StatusPass {
 		return findings
 	}
-	if weak, message := validate(strings.TrimSpace(headers.Get(name))); weak {
-		findings[0].Status = StatusWeak
-		findings[0].Message = message
+	for _, value := range headers.Values(name) {
+		if weak, message := validate(strings.TrimSpace(value)); weak {
+			findings[0].Status = StatusWeak
+			findings[0].Message = message
+			break
+		}
 	}
 	return findings
 }

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -1,7 +1,9 @@
 package scanner
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -30,12 +32,35 @@ func RunAll(checkers []Checker, headers http.Header) []Finding {
 type HSTSChecker struct{}
 
 func (HSTSChecker) Check(headers http.Header) []Finding {
-	return checkPresence(
+	return checkValue(
 		headers,
 		"Strict-Transport-Security",
 		SeverityHigh,
 		"https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html",
+		hstsWeakness,
 	)
+}
+
+// hstsWeakness flags an HSTS value whose max-age directive doesn't actually
+// enforce HTTPS: missing/unparseable (browsers ignore the header without a
+// valid max-age) or non-positive (max-age=0 tells the browser to stop
+// enforcing HTTPS immediately, which is a request to disable HSTS).
+func hstsWeakness(value string) (weak bool, message string) {
+	for _, directive := range strings.Split(value, ";") {
+		name, val, found := strings.Cut(strings.TrimSpace(directive), "=")
+		if !found || !strings.EqualFold(strings.TrimSpace(name), "max-age") {
+			continue
+		}
+		maxAge, err := strconv.Atoi(strings.TrimSpace(val))
+		if err != nil {
+			return true, fmt.Sprintf("max-age=%s is unparseable", strings.TrimSpace(val))
+		}
+		if maxAge <= 0 {
+			return true, fmt.Sprintf("max-age=%d disables HSTS", maxAge)
+		}
+		return false, ""
+	}
+	return true, "max-age directive is missing"
 }
 
 type ContentTypeOptionsChecker struct{}
@@ -52,12 +77,25 @@ func (ContentTypeOptionsChecker) Check(headers http.Header) []Finding {
 type FrameOptionsChecker struct{}
 
 func (FrameOptionsChecker) Check(headers http.Header) []Finding {
-	return checkPresence(
+	return checkValue(
 		headers,
 		"X-Frame-Options",
 		SeverityMedium,
 		"https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html",
+		frameOptionsWeakness,
 	)
+}
+
+// frameOptionsWeakness flags any value other than DENY/SAMEORIGIN: modern
+// browsers dropped support for ALLOW-FROM, and anything else is simply not
+// a value the spec defines, so neither provides clickjacking protection.
+func frameOptionsWeakness(value string) (weak bool, message string) {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "DENY", "SAMEORIGIN":
+		return false, ""
+	default:
+		return true, fmt.Sprintf("%q is not DENY or SAMEORIGIN and provides no clickjacking protection", value)
+	}
 }
 
 type CSPChecker struct{}
@@ -74,12 +112,23 @@ func (CSPChecker) Check(headers http.Header) []Finding {
 type ReferrerPolicyChecker struct{}
 
 func (ReferrerPolicyChecker) Check(headers http.Header) []Finding {
-	return checkPresence(
+	return checkValue(
 		headers,
 		"Referrer-Policy",
 		SeverityLow,
 		"https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#referrer-policy",
+		referrerPolicyWeakness,
 	)
+}
+
+// referrerPolicyWeakness flags unsafe-url, which explicitly sends the full
+// URL (including any query string) to third parties on every cross-origin
+// request — the opposite of what this header is for.
+func referrerPolicyWeakness(value string) (weak bool, message string) {
+	if strings.EqualFold(strings.TrimSpace(value), "unsafe-url") {
+		return true, "unsafe-url leaks the full URL, including query strings, to third parties on cross-origin requests"
+	}
+	return false, ""
 }
 
 func checkPresence(headers http.Header, name string, severity Severity, reference string) []Finding {
@@ -93,4 +142,20 @@ func checkPresence(headers http.Header, name string, severity Severity, referenc
 		Severity:  severity,
 		Reference: reference,
 	}}
+}
+
+// checkValue extends checkPresence with a validator for headers where a
+// present value can still be a functional no-op. Only a Finding that's
+// already StatusPass gets validated — missing/empty values stay StatusMissing,
+// since "provides no protection" and "isn't set" are different findings.
+func checkValue(headers http.Header, name string, severity Severity, reference string, validate func(value string) (weak bool, message string)) []Finding {
+	findings := checkPresence(headers, name, severity, reference)
+	if findings[0].Status != StatusPass {
+		return findings
+	}
+	if weak, message := validate(strings.TrimSpace(headers.Get(name))); weak {
+		findings[0].Status = StatusWeak
+		findings[0].Message = message
+	}
+	return findings
 }

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -12,12 +12,13 @@ func TestCheckersIdentity(t *testing.T) {
 		checker      scanner.Checker
 		wantHeader   string
 		wantSeverity scanner.Severity
+		validValue   string
 	}{
-		{scanner.HSTSChecker{}, "Strict-Transport-Security", scanner.SeverityHigh},
-		{scanner.ContentTypeOptionsChecker{}, "X-Content-Type-Options", scanner.SeverityMedium},
-		{scanner.FrameOptionsChecker{}, "X-Frame-Options", scanner.SeverityMedium},
-		{scanner.CSPChecker{}, "Content-Security-Policy", scanner.SeverityHigh},
-		{scanner.ReferrerPolicyChecker{}, "Referrer-Policy", scanner.SeverityLow},
+		{scanner.HSTSChecker{}, "Strict-Transport-Security", scanner.SeverityHigh, "max-age=63072000; includeSubDomains"},
+		{scanner.ContentTypeOptionsChecker{}, "X-Content-Type-Options", scanner.SeverityMedium, "nosniff"},
+		{scanner.FrameOptionsChecker{}, "X-Frame-Options", scanner.SeverityMedium, "DENY"},
+		{scanner.CSPChecker{}, "Content-Security-Policy", scanner.SeverityHigh, "default-src 'self'"},
+		{scanner.ReferrerPolicyChecker{}, "Referrer-Policy", scanner.SeverityLow, "strict-origin-when-cross-origin"},
 	}
 
 	for _, tt := range tests {
@@ -39,14 +40,95 @@ func TestCheckersIdentity(t *testing.T) {
 				t.Error("Reference is empty, want a docs URL")
 			}
 
-			present := tt.checker.Check(http.Header{tt.wantHeader: {"some-value"}})
+			present := tt.checker.Check(http.Header{tt.wantHeader: {tt.validValue}})
 			if present[0].Status != scanner.StatusPass {
-				t.Errorf("Status with header set = %q, want %q", present[0].Status, scanner.StatusPass)
+				t.Errorf("Status with valid value %q = %q, want %q", tt.validValue, present[0].Status, scanner.StatusPass)
 			}
 
 			empty := tt.checker.Check(http.Header{tt.wantHeader: {""}})
 			if empty[0].Status != scanner.StatusMissing {
 				t.Errorf("Status with empty header value = %q, want %q", empty[0].Status, scanner.StatusMissing)
+			}
+		})
+	}
+}
+
+func TestHSTSWeakValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"zero max-age", "max-age=0"},
+		{"negative max-age", "max-age=-1"},
+		{"unparseable max-age", "max-age=notanumber"},
+		{"missing max-age directive", "includeSubDomains"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.HSTSChecker{}.Check(http.Header{"Strict-Transport-Security": {tt.value}})
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestHSTSAcceptsValidMaxAge(t *testing.T) {
+	tests := []string{
+		"max-age=63072000",
+		"max-age=63072000; includeSubDomains",
+		"includeSubDomains; max-age=63072000",
+	}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.HSTSChecker{}.Check(http.Header{"Strict-Transport-Security": {value}})
+			if findings[0].Status != scanner.StatusPass {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
+			}
+		})
+	}
+}
+
+func TestFrameOptionsWeakValues(t *testing.T) {
+	tests := []string{"ALLOW-FROM https://example.com", "allowall", "garbage"}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.FrameOptionsChecker{}.Check(http.Header{"X-Frame-Options": {value}})
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestFrameOptionsAcceptsCaseInsensitiveValidValues(t *testing.T) {
+	tests := []string{"deny", "DENY", "sameorigin", "SAMEORIGIN"}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.FrameOptionsChecker{}.Check(http.Header{"X-Frame-Options": {value}})
+			if findings[0].Status != scanner.StatusPass {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
+			}
+		})
+	}
+}
+
+func TestReferrerPolicyWeakValues(t *testing.T) {
+	tests := []string{"unsafe-url", "UNSAFE-URL", "Unsafe-Url"}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.ReferrerPolicyChecker{}.Check(http.Header{"Referrer-Policy": {value}})
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
 			}
 		})
 	}

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -92,6 +92,27 @@ func TestHSTSAcceptsValidMaxAge(t *testing.T) {
 	}
 }
 
+func TestHSTSFlagsWeakAmongDuplicateHeaders(t *testing.T) {
+	// A misconfigured proxy/CDN can append a second Strict-Transport-Security
+	// header instead of overwriting the origin's. headers.Get would only see
+	// whichever value happens to be first, so the reported status must not
+	// depend on that order.
+	headers := http.Header{"Strict-Transport-Security": {"max-age=63072000", "max-age=0"}}
+	findings := scanner.HSTSChecker{}.Check(headers)
+	if findings[0].Status != scanner.StatusWeak {
+		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+	}
+	if findings[0].Message == "" {
+		t.Error("Message is empty, want an explanation")
+	}
+
+	reversed := http.Header{"Strict-Transport-Security": {"max-age=0", "max-age=63072000"}}
+	findings = scanner.HSTSChecker{}.Check(reversed)
+	if findings[0].Status != scanner.StatusWeak {
+		t.Errorf("Status = %q, want %q (order should not matter)", findings[0].Status, scanner.StatusWeak)
+	}
+}
+
 func TestFrameOptionsWeakValues(t *testing.T) {
 	tests := []string{"ALLOW-FROM https://example.com", "allowall", "garbage"}
 	for _, value := range tests {

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -113,6 +113,29 @@ func TestHSTSFlagsWeakAmongDuplicateHeaders(t *testing.T) {
 	}
 }
 
+func TestCheckValueIgnoresBlankDuplicateOccurrence(t *testing.T) {
+	// Some infra appends a stray empty duplicate header instead of leaving
+	// the original alone. That blank occurrence carries no value to judge
+	// and must not itself be treated as a weak one.
+	tests := []struct {
+		name    string
+		checker scanner.Checker
+		headers http.Header
+	}{
+		{"HSTS", scanner.HSTSChecker{}, http.Header{"Strict-Transport-Security": {"max-age=63072000", ""}}},
+		{"FrameOptions", scanner.FrameOptionsChecker{}, http.Header{"X-Frame-Options": {"DENY", ""}}},
+		{"ReferrerPolicy", scanner.ReferrerPolicyChecker{}, http.Header{"Referrer-Policy": {"strict-origin-when-cross-origin", ""}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := tt.checker.Check(tt.headers)
+			if findings[0].Status != scanner.StatusPass {
+				t.Errorf("Status = %q, want %q (blank duplicate should not downgrade a strong value)", findings[0].Status, scanner.StatusPass)
+			}
+		})
+	}
+}
+
 func TestFrameOptionsWeakValues(t *testing.T) {
 	tests := []string{"ALLOW-FROM https://example.com", "allowall", "garbage"}
 	for _, value := range tests {
@@ -152,5 +175,36 @@ func TestReferrerPolicyWeakValues(t *testing.T) {
 				t.Error("Message is empty, want an explanation")
 			}
 		})
+	}
+}
+
+func TestReferrerPolicyWeakFallbackList(t *testing.T) {
+	// A single value can be a comma-separated fallback list; per spec the
+	// browser applies the last *recognized* token, not the value verbatim.
+	tests := []string{
+		"strict-origin-when-cross-origin, unsafe-url",
+		"strict-origin-when-cross-origin, not-a-real-policy, unsafe-url",
+	}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.ReferrerPolicyChecker{}.Check(http.Header{"Referrer-Policy": {value}})
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestReferrerPolicyAcceptsFallbackListEndingStrong(t *testing.T) {
+	// The reverse order: an unsafe-url earlier in the list is overridden by
+	// a later recognized, safe token — that's the effective policy applied.
+	findings := scanner.ReferrerPolicyChecker{}.Check(http.Header{
+		"Referrer-Policy": {"unsafe-url, strict-origin-when-cross-origin"},
+	})
+	if findings[0].Status != scanner.StatusPass {
+		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
 	}
 }

--- a/internal/scanner/finding.go
+++ b/internal/scanner/finding.go
@@ -5,7 +5,12 @@ type Status string
 const (
 	StatusPass    Status = "pass"
 	StatusMissing Status = "missing"
-	StatusError   Status = "error"
+	// StatusWeak marks a header that is present but whose value is a known
+	// no-op, so it doesn't provide the protection the header exists for.
+	// Kept distinct from StatusPass so scans don't silently treat a
+	// self-defeating value (e.g. max-age=0) as a clean bill of health.
+	StatusWeak  Status = "weak"
+	StatusError Status = "error"
 )
 
 type Severity string

--- a/internal/scanner/report.go
+++ b/internal/scanner/report.go
@@ -38,8 +38,8 @@ func colorize(color, s string) string {
 	return color + s + ansiReset
 }
 
-// statusTag picks the color from severity for missing headers so a missing
-// high-severity header reads as urgent (red) while lower severities stay a
+// statusTag picks the color from severity for missing/weak headers so a
+// high-severity finding reads as urgent (red) while lower severities stay a
 // warning yellow.
 func statusTag(f Finding) string {
 	switch f.Status {
@@ -48,10 +48,14 @@ func statusTag(f Finding) string {
 	case StatusError:
 		return colorize(ansiRed, "ERROR")
 	}
+	color := ansiYellow
 	if f.Severity == SeverityHigh {
-		return colorize(ansiRed, "MISSING")
+		color = ansiRed
 	}
-	return colorize(ansiYellow, "MISSING")
+	if f.Status == StatusWeak {
+		return colorize(color, "WEAK")
+	}
+	return colorize(color, "MISSING")
 }
 
 type TerminalReporter struct{}
@@ -76,6 +80,9 @@ func (TerminalReporter) Report(findings []Finding, w io.Writer) error {
 				line = fmt.Sprintf("  [%s] %s", statusTag(f), f.Message)
 			} else {
 				line = fmt.Sprintf("  [%s] %s (%s)", statusTag(f), f.Header, f.Severity)
+				if f.Status == StatusWeak && f.Message != "" {
+					line += ": " + f.Message
+				}
 				if f.Status != StatusPass && f.Reference != "" {
 					line += " → " + f.Reference
 				}

--- a/internal/scanner/report_test.go
+++ b/internal/scanner/report_test.go
@@ -62,6 +62,36 @@ func TestTerminalReporterGroupsFindingsByURL(t *testing.T) {
 	}
 }
 
+func TestTerminalReporterShowsWeakMessage(t *testing.T) {
+	findings := []scanner.Finding{
+		{
+			URL:       "https://a.example",
+			Header:    "Strict-Transport-Security",
+			Status:    scanner.StatusWeak,
+			Severity:  scanner.SeverityHigh,
+			Message:   "max-age=0 disables HSTS",
+			Reference: "https://owasp.example/hsts",
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := (scanner.TerminalReporter{}).Report(findings, &buf); err != nil {
+		t.Fatalf("Report() returned error: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{"WEAK", "Strict-Transport-Security", "max-age=0 disables HSTS", "https://owasp.example/hsts"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\noutput:\n%s", want, out)
+		}
+	}
+
+	//nolint:gosec // G101 false positive: ANSI color assertion, not credentials
+	if !strings.Contains(out, "\x1b[31mWEAK\x1b[0m") {
+		t.Errorf("WEAK tag for high-severity finding is not red\noutput:\n%q", out)
+	}
+}
+
 func TestTerminalReporterShowsErrorMessage(t *testing.T) {
 	findings := []scanner.Finding{
 		{
@@ -151,6 +181,14 @@ func TestJSONReporterEmitsOneFindingPerLine(t *testing.T) {
 			Status:  scanner.StatusError,
 			Message: "context deadline exceeded",
 		},
+		{
+			URL:       "https://a.example",
+			Header:    "Referrer-Policy",
+			Status:    scanner.StatusWeak,
+			Severity:  scanner.SeverityLow,
+			Message:   "unsafe-url leaks the full URL, including query strings, to third parties on cross-origin requests",
+			Reference: "https://owasp.example/referrer-policy",
+		},
 	}
 
 	var buf bytes.Buffer
@@ -159,8 +197,8 @@ func TestJSONReporterEmitsOneFindingPerLine(t *testing.T) {
 	}
 
 	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("got %d lines, want one per finding (2)\noutput:\n%s", len(lines), buf.String())
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want one per finding (3)\noutput:\n%s", len(lines), buf.String())
 	}
 
 	var first map[string]any
@@ -188,5 +226,16 @@ func TestJSONReporterEmitsOneFindingPerLine(t *testing.T) {
 	}
 	if second["message"] != "context deadline exceeded" {
 		t.Errorf("error finding message = %v, want the scan error", second["message"])
+	}
+
+	var third map[string]any
+	if err := json.Unmarshal([]byte(lines[2]), &third); err != nil {
+		t.Fatalf("line 3 is not valid JSON: %v\nline: %s", err, lines[2])
+	}
+	if third["status"] != "weak" {
+		t.Errorf("weak finding status = %v, want %q", third["status"], "weak")
+	}
+	if third["message"] != "unsafe-url leaks the full URL, including query strings, to third parties on cross-origin requests" {
+		t.Errorf("weak finding message = %v, want the weakness explanation", third["message"])
 	}
 }

--- a/site/checks/referrer-policy.md
+++ b/site/checks/referrer-policy.md
@@ -23,7 +23,7 @@ This is the browser default since 2021 and a safe choice for most APIs. More res
 
 ## What mamori checks
 
-Presence of the header. A missing header is reported as a low-severity finding.
+Presence of the header, and that it isn't set to `unsafe-url`. A missing header is reported as a low-severity finding. A present header set to `unsafe-url` is reported as `WEAK` — it explicitly sends the full URL, including query strings, to third parties on every cross-origin request, the opposite of what this header is for.
 
 ## Further reading
 

--- a/site/checks/strict-transport-security.md
+++ b/site/checks/strict-transport-security.md
@@ -21,7 +21,7 @@ Strict-Transport-Security: max-age=63072000; includeSubDomains
 
 ## What mamori checks
 
-Presence of the header. A missing or empty header is reported as a high-severity finding.
+Presence of the header, and that `max-age` actually enforces HTTPS. A missing or empty header is reported as a high-severity finding. A present header with a missing, unparseable, or non-positive `max-age` (e.g. `max-age=0`) is reported as `WEAK` — it disables HSTS just as effectively as not sending the header at all.
 
 ## Further reading
 

--- a/site/checks/x-frame-options.md
+++ b/site/checks/x-frame-options.md
@@ -27,7 +27,7 @@ X-Frame-Options: SAMEORIGIN
 
 ## What mamori checks
 
-Presence of the header. A missing header is reported as a medium-severity finding.
+Presence of the header, and that its value is one of the two the spec defines. A missing header is reported as a medium-severity finding. A present header with any value other than `DENY`/`SAMEORIGIN` (case-insensitive) — including `ALLOW-FROM`, which modern browsers ignore — is reported as `WEAK`, since it provides no clickjacking protection.
 
 ## Further reading
 


### PR DESCRIPTION
## What / Why

`checkPresence` only verified a security header had *some* non-empty value, so no-op values passed silently:

- `Strict-Transport-Security: max-age=0` — tells the browser to stop enforcing HTTPS immediately.
- `X-Frame-Options: ALLOW-FROM ...` (or anything but `DENY`/`SAMEORIGIN`) — ignored by modern browsers, no clickjacking protection.
- `Referrer-Policy: unsafe-url` — leaks the full URL, including query strings, to third parties.

Adds a `StatusWeak` status distinct from `StatusPass`/`StatusMissing`/`StatusError`, and extends `HSTSChecker`, `FrameOptionsChecker`, and `ReferrerPolicyChecker` to downgrade to `StatusWeak` (with a descriptive `Message`) for these known no-op values, after confirming presence. `CSPChecker` and `ContentTypeOptionsChecker` are untouched, per the issue's scope (CSP value validation is application-specific and explicitly out of scope).

`report.go`'s `statusTag` renders `StatusWeak` as its own `WEAK` tag, colored red/yellow by severity the same way `MISSING` is. The terminal reporter also surfaces the `Message` for weak findings so the "why" isn't silently dropped. `JSONReporter` needed no changes — it already serializes whatever `Status`/`Message` a finding carries.

## Test evidence

```
$ go build ./... && go vet ./... && go test ./...
ok  	github.com/PhyberApex/mamori/internal/config	0.002s
ok  	github.com/PhyberApex/mamori/internal/scanner	0.117s
```

New test coverage:
- `TestHSTSWeakValues` / `TestHSTSAcceptsValidMaxAge` — zero/negative/unparseable/missing `max-age` vs. valid values (including directive order and `includeSubDomains`).
- `TestFrameOptionsWeakValues` / `TestFrameOptionsAcceptsCaseInsensitiveValidValues` — `ALLOW-FROM`/garbage vs. case-insensitive `DENY`/`SAMEORIGIN`.
- `TestReferrerPolicyWeakValues` — case-insensitive `unsafe-url`.
- `TestTerminalReporterShowsWeakMessage` and a `StatusWeak` case in `TestJSONReporterEmitsOneFindingPerLine` for reporter rendering.
- `TestCheckersIdentity` updated to use a per-checker valid value (previously asserted `StatusPass` for a generic `"some-value"`, which is no longer true for the three checkers that now validate values).

Also updated `site/checks/strict-transport-security.md`, `x-frame-options.md`, and `referrer-policy.md`'s "What mamori checks" sections to describe the new validation.

Closes #25

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*