### PR TITLE
fix(scanner): validate X-Content-Type-Options is nosniff, not just present

### DIFF
--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -66,12 +66,23 @@ func hstsWeakness(value string) (weak bool, message string) {
 type ContentTypeOptionsChecker struct{}
 
 func (ContentTypeOptionsChecker) Check(headers http.Header) []Finding {
-	return checkPresence(
+	return checkValue(
 		headers,
 		"X-Content-Type-Options",
 		SeverityMedium,
 		"https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-content-type-options",
+		contentTypeOptionsWeakness,
 	)
+}
+
+// contentTypeOptionsWeakness flags any value other than nosniff: it's the
+// only value this header defines, so anything else is not recognized by
+// browsers and disables MIME-sniffing protection just like a missing header.
+func contentTypeOptionsWeakness(value string) (weak bool, message string) {
+	if strings.EqualFold(strings.TrimSpace(value), "nosniff") {
+		return false, ""
+	}
+	return true, fmt.Sprintf("%q is not nosniff and has no effect", value)
 }
 
 type FrameOptionsChecker struct{}

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -123,6 +123,7 @@ func TestCheckValueIgnoresBlankDuplicateOccurrence(t *testing.T) {
 		headers http.Header
 	}{
 		{"HSTS", scanner.HSTSChecker{}, http.Header{"Strict-Transport-Security": {"max-age=63072000", ""}}},
+		{"ContentTypeOptions", scanner.ContentTypeOptionsChecker{}, http.Header{"X-Content-Type-Options": {"nosniff", ""}}},
 		{"FrameOptions", scanner.FrameOptionsChecker{}, http.Header{"X-Frame-Options": {"DENY", ""}}},
 		{"ReferrerPolicy", scanner.ReferrerPolicyChecker{}, http.Header{"Referrer-Policy": {"strict-origin-when-cross-origin", ""}}},
 	}
@@ -131,6 +132,33 @@ func TestCheckValueIgnoresBlankDuplicateOccurrence(t *testing.T) {
 			findings := tt.checker.Check(tt.headers)
 			if findings[0].Status != scanner.StatusPass {
 				t.Errorf("Status = %q, want %q (blank duplicate should not downgrade a strong value)", findings[0].Status, scanner.StatusPass)
+			}
+		})
+	}
+}
+
+func TestContentTypeOptionsWeakValues(t *testing.T) {
+	tests := []string{"garbage", "sniff"}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.ContentTypeOptionsChecker{}.Check(http.Header{"X-Content-Type-Options": {value}})
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestContentTypeOptionsAcceptsCaseInsensitiveValidValue(t *testing.T) {
+	tests := []string{"nosniff", "NOSNIFF", "NoSniff"}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.ContentTypeOptionsChecker{}.Check(http.Header{"X-Content-Type-Options": {value}})
+			if findings[0].Status != scanner.StatusPass {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
 			}
 		})
 	}


### PR DESCRIPTION
## What

`ContentTypeOptionsChecker.Check` now calls `checkValue` with a new `contentTypeOptionsWeakness` validator instead of `checkPresence`, flagging any `X-Content-Type-Options` value other than `nosniff` (case-insensitive) as `StatusWeak`.

## Why

`nosniff` is the only value this header defines; any other value is not recognized by browsers and provides no MIME-sniffing protection, but `checkPresence` reported it as `StatusPass`. `site/checks/x-content-type-options.md` already documented the value-checking behavior — this was the one checker in `internal/scanner/checkers.go` left on `checkPresence` despite that. Same pattern already applied to HSTS, X-Frame-Options, and Referrer-Policy in #26.

## Test evidence

- Added `TestContentTypeOptionsWeakValues` (mirrors `TestFrameOptionsWeakValues`) covering non-`nosniff` values.
- Added `TestContentTypeOptionsAcceptsCaseInsensitiveValidValue` covering `nosniff`/`NOSNIFF`/`NoSniff`.
- Added the `ContentTypeOptions` case to `TestCheckValueIgnoresBlankDuplicateOccurrence`, since it now goes through `checkValue` like the other duplicate-header-aware checkers.
- `TestCheckersIdentity`'s existing `"nosniff"` `validValue` case for this checker continues to pass.
- `go build ./... && go vet ./... && go test ./...` all pass.

Closes #27

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*