### PR TITLE
feat(scanner): add Set-Cookie checker for Secure, HttpOnly, SameSite

### DIFF
--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -185,40 +185,40 @@ func (CookieChecker) Check(headers http.Header) []Finding {
 	return findings
 }
 
+// cookieAttributes lists the three flags CookieChecker judges, in the order
+// findings are reported. Go only sets SameSite to Lax/Strict when the
+// attribute is explicitly present with a recognized value; a missing
+// attribute leaves the zero value, and an unrecognized value maps to
+// SameSiteDefaultMode, so anything other than Lax/Strict is either absent
+// or explicit None.
+var cookieAttributes = []struct {
+	name     string
+	severity Severity
+	weak     func(cookie *http.Cookie) bool
+	message  string
+}{
+	{"Secure", SeverityHigh, func(c *http.Cookie) bool { return !c.Secure }, "lacks the Secure flag and can be sent over plain HTTP"},
+	{"HttpOnly", SeverityMedium, func(c *http.Cookie) bool { return !c.HttpOnly }, "lacks the HttpOnly flag and can be read by client-side JavaScript"},
+	{"SameSite", SeverityMedium, func(c *http.Cookie) bool {
+		return c.SameSite != http.SameSiteLaxMode && c.SameSite != http.SameSiteStrictMode
+	}, "is missing SameSite=Strict/Lax and will be sent on cross-site requests"},
+}
+
 // cookieFindings reports each weak attribute of a single cookie
 // independently, mirroring how the other checkers emit one Finding per
 // header rather than bundling unrelated weaknesses into one message.
 func cookieFindings(cookie *http.Cookie) []Finding {
 	var findings []Finding
-	if !cookie.Secure {
+	for _, attr := range cookieAttributes {
+		if !attr.weak(cookie) {
+			continue
+		}
 		findings = append(findings, Finding{
-			Header:    fmt.Sprintf("Set-Cookie: %s (Secure)", cookie.Name),
+			Header:    fmt.Sprintf("Set-Cookie: %s (%s)", cookie.Name, attr.name),
 			Status:    StatusWeak,
-			Severity:  SeverityHigh,
+			Severity:  attr.severity,
 			Reference: cookieReference,
-			Message:   fmt.Sprintf("cookie %q lacks the Secure flag and can be sent over plain HTTP", cookie.Name),
-		})
-	}
-	if !cookie.HttpOnly {
-		findings = append(findings, Finding{
-			Header:    fmt.Sprintf("Set-Cookie: %s (HttpOnly)", cookie.Name),
-			Status:    StatusWeak,
-			Severity:  SeverityMedium,
-			Reference: cookieReference,
-			Message:   fmt.Sprintf("cookie %q lacks the HttpOnly flag and can be read by client-side JavaScript", cookie.Name),
-		})
-	}
-	// Go only sets SameSite to Lax/Strict when the attribute is explicitly
-	// present with a recognized value; a missing attribute leaves the zero
-	// value, and an unrecognized value maps to SameSiteDefaultMode, so
-	// anything other than Lax/Strict is either absent or explicit None.
-	if cookie.SameSite != http.SameSiteLaxMode && cookie.SameSite != http.SameSiteStrictMode {
-		findings = append(findings, Finding{
-			Header:    fmt.Sprintf("Set-Cookie: %s (SameSite)", cookie.Name),
-			Status:    StatusWeak,
-			Severity:  SeverityMedium,
-			Reference: cookieReference,
-			Message:   fmt.Sprintf("cookie %q is missing SameSite=Strict/Lax and will be sent on cross-site requests", cookie.Name),
+			Message:   fmt.Sprintf("cookie %q %s", cookie.Name, attr.message),
 		})
 	}
 	return findings

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -18,6 +18,7 @@ func DefaultCheckers() []Checker {
 		FrameOptionsChecker{},
 		CSPChecker{},
 		ReferrerPolicyChecker{},
+		CookieChecker{},
 	}
 }
 
@@ -161,6 +162,66 @@ func effectiveReferrerPolicy(value string) string {
 		}
 	}
 	return effective
+}
+
+const cookieReference = "https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html"
+
+// CookieChecker inspects every Set-Cookie header for the three flags that
+// keep a cookie from being trivially stolen or forged: Secure, HttpOnly, and
+// SameSite. Unlike the other checkers, a response with no cookies has
+// nothing to protect, so no Set-Cookie header is not itself a finding — only
+// a present-but-weak cookie is.
+type CookieChecker struct{}
+
+func (CookieChecker) Check(headers http.Header) []Finding {
+	var findings []Finding
+	for _, line := range headers.Values("Set-Cookie") {
+		cookie, err := http.ParseSetCookie(line)
+		if err != nil {
+			continue
+		}
+		findings = append(findings, cookieFindings(cookie)...)
+	}
+	return findings
+}
+
+// cookieFindings reports each weak attribute of a single cookie
+// independently, mirroring how the other checkers emit one Finding per
+// header rather than bundling unrelated weaknesses into one message.
+func cookieFindings(cookie *http.Cookie) []Finding {
+	var findings []Finding
+	if !cookie.Secure {
+		findings = append(findings, Finding{
+			Header:    fmt.Sprintf("Set-Cookie: %s (Secure)", cookie.Name),
+			Status:    StatusWeak,
+			Severity:  SeverityHigh,
+			Reference: cookieReference,
+			Message:   fmt.Sprintf("cookie %q lacks the Secure flag and can be sent over plain HTTP", cookie.Name),
+		})
+	}
+	if !cookie.HttpOnly {
+		findings = append(findings, Finding{
+			Header:    fmt.Sprintf("Set-Cookie: %s (HttpOnly)", cookie.Name),
+			Status:    StatusWeak,
+			Severity:  SeverityMedium,
+			Reference: cookieReference,
+			Message:   fmt.Sprintf("cookie %q lacks the HttpOnly flag and can be read by client-side JavaScript", cookie.Name),
+		})
+	}
+	// Go only sets SameSite to Lax/Strict when the attribute is explicitly
+	// present with a recognized value; a missing attribute leaves the zero
+	// value, and an unrecognized value maps to SameSiteDefaultMode, so
+	// anything other than Lax/Strict is either absent or explicit None.
+	if cookie.SameSite != http.SameSiteLaxMode && cookie.SameSite != http.SameSiteStrictMode {
+		findings = append(findings, Finding{
+			Header:    fmt.Sprintf("Set-Cookie: %s (SameSite)", cookie.Name),
+			Status:    StatusWeak,
+			Severity:  SeverityMedium,
+			Reference: cookieReference,
+			Message:   fmt.Sprintf("cookie %q is missing SameSite=Strict/Lax and will be sent on cross-site requests", cookie.Name),
+		})
+	}
+	return findings
 }
 
 func checkPresence(headers http.Header, name string, severity Severity, reference string) []Finding {

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -2,6 +2,7 @@ package scanner_test
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/PhyberApex/mamori/internal/scanner"
@@ -195,6 +196,134 @@ func TestReferrerPolicyWeakFallbackList(t *testing.T) {
 				t.Error("Message is empty, want an explanation")
 			}
 		})
+	}
+}
+
+func TestCookieCheckerNoCookiesProducesNoFindings(t *testing.T) {
+	findings := scanner.CookieChecker{}.Check(http.Header{})
+	if len(findings) != 0 {
+		t.Errorf("Check() on headers with no Set-Cookie returned %d findings, want 0", len(findings))
+	}
+}
+
+func TestCookieCheckerFullyLockedDownCookieProducesNoFindings(t *testing.T) {
+	findings := scanner.CookieChecker{}.Check(http.Header{
+		"Set-Cookie": {"session_id=abc123; Secure; HttpOnly; SameSite=Strict"},
+	})
+	if len(findings) != 0 {
+		t.Errorf("Check() on a fully-locked-down cookie returned %d findings, want 0: %+v", len(findings), findings)
+	}
+}
+
+func TestCookieCheckerSameSiteLaxIsAccepted(t *testing.T) {
+	findings := scanner.CookieChecker{}.Check(http.Header{
+		"Set-Cookie": {"session_id=abc123; Secure; HttpOnly; SameSite=Lax"},
+	})
+	if len(findings) != 0 {
+		t.Errorf("Check() with SameSite=Lax returned %d findings, want 0: %+v", len(findings), findings)
+	}
+}
+
+func TestCookieCheckerMissingSecure(t *testing.T) {
+	findings := scanner.CookieChecker{}.Check(http.Header{
+		"Set-Cookie": {"session_id=abc123; HttpOnly; SameSite=Strict"},
+	})
+	if len(findings) != 1 {
+		t.Fatalf("Check() returned %d findings, want 1: %+v", len(findings), findings)
+	}
+	if findings[0].Status != scanner.StatusWeak {
+		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+	}
+	if findings[0].Severity != scanner.SeverityHigh {
+		t.Errorf("Severity = %q, want %q", findings[0].Severity, scanner.SeverityHigh)
+	}
+	if findings[0].Header != "Set-Cookie: session_id (Secure)" {
+		t.Errorf("Header = %q, want %q", findings[0].Header, "Set-Cookie: session_id (Secure)")
+	}
+	if findings[0].Message == "" {
+		t.Error("Message is empty, want an explanation")
+	}
+}
+
+func TestCookieCheckerMissingHttpOnly(t *testing.T) {
+	findings := scanner.CookieChecker{}.Check(http.Header{
+		"Set-Cookie": {"session_id=abc123; Secure; SameSite=Strict"},
+	})
+	if len(findings) != 1 {
+		t.Fatalf("Check() returned %d findings, want 1: %+v", len(findings), findings)
+	}
+	if findings[0].Status != scanner.StatusWeak {
+		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+	}
+	if findings[0].Severity != scanner.SeverityMedium {
+		t.Errorf("Severity = %q, want %q", findings[0].Severity, scanner.SeverityMedium)
+	}
+	if findings[0].Header != "Set-Cookie: session_id (HttpOnly)" {
+		t.Errorf("Header = %q, want %q", findings[0].Header, "Set-Cookie: session_id (HttpOnly)")
+	}
+	if findings[0].Message == "" {
+		t.Error("Message is empty, want an explanation")
+	}
+}
+
+func TestCookieCheckerWeakSameSite(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"missing SameSite", "session_id=abc123; Secure; HttpOnly"},
+		{"SameSite=None", "session_id=abc123; Secure; HttpOnly; SameSite=None"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.CookieChecker{}.Check(http.Header{"Set-Cookie": {tt.value}})
+			if len(findings) != 1 {
+				t.Fatalf("Check() returned %d findings, want 1: %+v", len(findings), findings)
+			}
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Severity != scanner.SeverityMedium {
+				t.Errorf("Severity = %q, want %q", findings[0].Severity, scanner.SeverityMedium)
+			}
+			if findings[0].Header != "Set-Cookie: session_id (SameSite)" {
+				t.Errorf("Header = %q, want %q", findings[0].Header, "Set-Cookie: session_id (SameSite)")
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestCookieCheckerCompletelyInsecureCookieProducesThreeFindings(t *testing.T) {
+	findings := scanner.CookieChecker{}.Check(http.Header{
+		"Set-Cookie": {"session_id=abc123"},
+	})
+	if len(findings) != 3 {
+		t.Fatalf("Check() returned %d findings, want 3: %+v", len(findings), findings)
+	}
+	for _, f := range findings {
+		if f.Status != scanner.StatusWeak {
+			t.Errorf("Status = %q, want %q", f.Status, scanner.StatusWeak)
+		}
+	}
+}
+
+func TestCookieCheckerEvaluatesMultipleCookiesIndependently(t *testing.T) {
+	findings := scanner.CookieChecker{}.Check(http.Header{
+		"Set-Cookie": {
+			"session_id=abc123; Secure; HttpOnly; SameSite=Strict",
+			"tracking_id=xyz789",
+		},
+	})
+	if len(findings) != 3 {
+		t.Fatalf("Check() returned %d findings, want 3 (only from tracking_id): %+v", len(findings), findings)
+	}
+	for _, f := range findings {
+		if !strings.Contains(f.Header, "tracking_id") {
+			t.Errorf("Header = %q, want it to reference tracking_id only", f.Header)
+		}
 	}
 }
 

--- a/internal/scanner/runall_test.go
+++ b/internal/scanner/runall_test.go
@@ -17,6 +17,10 @@ func TestRunAllFansOutAcrossDefaultCheckers(t *testing.T) {
 		statusByHeader[f.Header] = f.Status
 	}
 
+	// No Set-Cookie header is present, so CookieChecker contributes no
+	// findings here (unlike the other checkers, an absent cookie jar isn't
+	// itself a finding) and the expected count/map below is unaffected by
+	// its inclusion in DefaultCheckers().
 	want := map[string]scanner.Status{
 		"Strict-Transport-Security": scanner.StatusMissing,
 		"X-Content-Type-Options":    scanner.StatusMissing,

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -10,3 +10,4 @@ header_pages:
   - checks/x-frame-options.md
   - checks/content-security-policy.md
   - checks/referrer-policy.md
+  - checks/set-cookie.md

--- a/site/checks/set-cookie.md
+++ b/site/checks/set-cookie.md
@@ -1,0 +1,38 @@
+---
+layout: page
+title: Set-Cookie
+permalink: /checks/set-cookie
+---
+
+**Severity:** high (`Secure`), medium (`HttpOnly`, `SameSite`)
+
+## What it does
+
+Checks the flags on every cookie a response sets. These flags control whether a cookie can be sent over plain HTTP, read by JavaScript, or attached to cross-site requests — the three most common ways a cookie ends up stolen or abused for CSRF.
+
+## Expected value
+
+```
+Set-Cookie: session_id=...; Secure; HttpOnly; SameSite=Strict
+```
+
+- `Secure` — the cookie is only ever sent over HTTPS, never in the clear over plain HTTP.
+- `HttpOnly` — the cookie is invisible to client-side JavaScript, limiting what an XSS bug can steal.
+- `SameSite=Strict` or `SameSite=Lax` — the cookie isn't attached to cross-site requests, mitigating CSRF.
+
+## What mamori checks
+
+Every `Set-Cookie` header in the response, parsed independently. A response with no cookies has nothing to protect, so no `Set-Cookie` header is not itself a finding — mamori only flags cookies that are actually present and weak.
+
+For each cookie, mamori reports up to three independent `WEAK` findings:
+
+- Missing `Secure` — high severity; the cookie can be sent over plain HTTP.
+- Missing `HttpOnly` — medium severity; the cookie is readable by client-side JavaScript.
+- Missing `SameSite`, or `SameSite=None` — medium severity; the cookie is sent on cross-site requests.
+
+A cookie with all three set correctly (`Secure; HttpOnly; SameSite=Strict` or `SameSite=Lax`) produces no findings. Multiple cookies in the same response are each evaluated on their own merits.
+
+## Further reading
+
+- [MDN: Set-Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)
+- [OWASP: Session Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html)

--- a/site/index.md
+++ b/site/index.md
@@ -14,3 +14,4 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `X-Frame-Options` | medium | [docs](checks/x-frame-options) |
 | `Content-Security-Policy` | high | [docs](checks/content-security-policy) |
 | `Referrer-Policy` | low | [docs](checks/referrer-policy) |
+| `Set-Cookie` | high / medium | [docs](checks/set-cookie) |


### PR DESCRIPTION
## What / why

mamori's header checks (HSTS, CSP, frame/content-type options, referrer policy) had no coverage for `Set-Cookie`, even though missing cookie flags are one of the most common, objectively-checkable classes of finding for an API scanner:

- No `Secure` — the cookie can be sent in the clear over plain HTTP.
- No `HttpOnly` — client-side JavaScript can read the cookie, raising the impact of any XSS.
- No `SameSite=Strict`/`Lax` (missing, or explicit `SameSite=None`) — the cookie is attached to cross-site requests, enabling CSRF.

This adds a `CookieChecker`, registered in `DefaultCheckers()`, that parses every `Set-Cookie` header and reports up to three independent `WEAK` findings per cookie (mirroring how HSTS/X-Frame-Options/Referrer-Policy are each their own finding rather than bundled).

Unlike the other checkers, an absent `Set-Cookie` header is **not** a finding — a response with no cookies has nothing to protect, so `CookieChecker.Check` returns an empty slice in that case (not `StatusMissing`).

`Finding.Header` identifies both the cookie and the weak attribute, e.g. `Set-Cookie: session_id (Secure)`, so terminal/JSON output can distinguish multiple cookies and multiple weak attributes on the same cookie.

Note: the issue suggested `http.ReadSetCookies(headers)`, but that function isn't exported in the Go version used by this repo (go1.26.3) — only `http.ParseSetCookie(line string)` is. The checker instead iterates `headers.Values("Set-Cookie")` and calls `http.ParseSetCookie` per line, skipping any that fail to parse.

## Test evidence

```
$ go build ./... && go vet ./... && go test ./...
ok  	github.com/PhyberApex/mamori/internal/config
ok  	github.com/PhyberApex/mamori/internal/scanner
```

New table-driven tests in `checkers_test.go` cover: no cookies → no findings, fully-locked-down cookie → no findings, `SameSite=Lax` accepted, missing `Secure`/`HttpOnly`/`SameSite` each produce the correct severity and message, `SameSite=None` treated as weak, a fully-open cookie produces all three findings, and multiple `Set-Cookie` headers are evaluated independently. `runall_test.go`'s `TestRunAllFansOutAcrossDefaultCheckers` still holds unchanged (a comment now explains why).

Also adds `site/checks/set-cookie.md` (following the existing format) and wires it into `site/_config.yml` / `site/index.md`.

Closes #28

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*