### PR TITLE
feat(cli): add -fail-on flag so CI can gate on scan severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,18 @@ Full reference for every check mamori performs is available at
 | `-workers` | `10` | number of concurrent scan workers |
 | `-timeout` | `10s` | HTTP request timeout (e.g. `5s`) |
 | `-o` | `terminal` | output format: `terminal` or `json` |
+| `-fail-on` | `none` | exit non-zero on findings at or above this severity: `low`, `medium`, `high`, or `none` |
 
 `-o json` emits newline-delimited JSON, one finding per line.
+
+`-fail-on` gates the exit code on the scan's own findings, for use as a CI
+check. The default, `none`, never fails — the exit code stays `0` no matter
+what the scan finds. Set it to `low`, `medium`, or `high` to enable gating:
+a `missing` or `weak` finding fails once its severity reaches the configured
+threshold, and a finding that couldn't be scanned at all (`error`) always
+fails, regardless of threshold. When the gate trips, `mamori` exits `1`
+without an extra error line, since the report above has already shown which
+finding is responsible.
 
 ### Environment variables
 
@@ -79,6 +89,7 @@ precedence.
 | `MAMORI_WORKERS` | `-workers` |
 | `MAMORI_TIMEOUT` | `-timeout` |
 | `MAMORI_OUTPUT` | `-o` |
+| `MAMORI_FAIL_ON` | `-fail-on` |
 
 ## License
 

--- a/cmd/mamori/main.go
+++ b/cmd/mamori/main.go
@@ -58,7 +58,7 @@ func run(args []string, stdin io.Reader, out io.Writer) error {
 	if err := reporterFor(cfg.Output).Report(findings, out); err != nil {
 		return err
 	}
-	if cfg.FailOn != "" && scanner.AnyFails(findings, cfg.FailOn) {
+	if scanner.AnyFails(findings, cfg.FailOn) {
 		return errFailThreshold
 	}
 	return nil

--- a/cmd/mamori/main.go
+++ b/cmd/mamori/main.go
@@ -13,6 +13,13 @@ import (
 	"github.com/PhyberApex/mamori/internal/scanner"
 )
 
+// errFailThreshold signals that -fail-on tripped on the scan's own findings,
+// not that the scan malfunctioned. main() checks for it specifically so it
+// can exit non-zero without the "mamori: ..." line a real failure gets — the
+// report already written to out has told the user exactly what's wrong, so
+// repeating that as a generic error would just be noise.
+var errFailThreshold = errors.New("findings at or above the -fail-on threshold")
+
 func main() {
 	if err := run(os.Args[1:], stdinIfPiped(), os.Stdout); err != nil {
 		// -h/-help surfaces as flag.ErrHelp after the FlagSet has already
@@ -20,7 +27,9 @@ func main() {
 		if errors.Is(err, flag.ErrHelp) {
 			return
 		}
-		fmt.Fprintln(os.Stderr, "mamori:", err)
+		if !errors.Is(err, errFailThreshold) {
+			fmt.Fprintln(os.Stderr, "mamori:", err)
+		}
 		os.Exit(1)
 	}
 }
@@ -46,7 +55,13 @@ func run(args []string, stdin io.Reader, out io.Writer) error {
 	}
 	client := &http.Client{Timeout: cfg.Timeout}
 	findings := scanner.Scan(context.Background(), client, scanner.DefaultCheckers(), urls, cfg.Workers)
-	return reporterFor(cfg.Output).Report(findings, out)
+	if err := reporterFor(cfg.Output).Report(findings, out); err != nil {
+		return err
+	}
+	if cfg.FailOn != "" && scanner.AnyFails(findings, cfg.FailOn) {
+		return errFailThreshold
+	}
+	return nil
 }
 
 // reporterFor returns the Reporter interface, not a concrete type, so run

--- a/cmd/mamori/main_test.go
+++ b/cmd/mamori/main_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// strongHeaders returns headers that pass every default checker, so a
+// server built from this map alone never trips -fail-on at any severity.
+func strongHeaders() map[string]string {
+	return map[string]string{
+		"Strict-Transport-Security": "max-age=63072000; includeSubDomains",
+		"X-Content-Type-Options":    "nosniff",
+		"X-Frame-Options":           "DENY",
+		"Content-Security-Policy":   "default-src 'self'",
+		"Referrer-Policy":           "strict-origin-when-cross-origin",
+	}
+}
+
+func headerServer(t *testing.T, headers map[string]string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for name, value := range headers {
+			w.Header().Set(name, value)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestRunDefaultNeverFailsOnFindings(t *testing.T) {
+	url := headerServer(t, nil) // every header missing, including high severity
+	if err := run([]string{url}, nil, io.Discard); err != nil {
+		t.Errorf("run() with -fail-on unset returned %v, want nil", err)
+	}
+}
+
+func TestRunFailOnMediumFailsOnMissingFindings(t *testing.T) {
+	url := headerServer(t, nil)
+	err := run([]string{"-fail-on", "medium", url}, nil, io.Discard)
+	if !errors.Is(err, errFailThreshold) {
+		t.Errorf("run() with -fail-on medium returned %v, want errFailThreshold", err)
+	}
+}
+
+func TestRunFailOnHighIgnoresMediumWeakFinding(t *testing.T) {
+	headers := strongHeaders()
+	// ALLOW-FROM is not DENY/SAMEORIGIN, so this is StatusWeak at
+	// SeverityMedium — below the -fail-on high threshold.
+	headers["X-Frame-Options"] = "ALLOW-FROM https://example.com"
+	url := headerServer(t, headers)
+
+	if err := run([]string{"-fail-on", "high", url}, nil, io.Discard); err != nil {
+		t.Errorf("run() with -fail-on high returned %v, want nil for a medium-severity weak finding", err)
+	}
+}
+
+func TestRunFailOnHighFailsOnHighSeverityMissingFinding(t *testing.T) {
+	headers := strongHeaders()
+	delete(headers, "Content-Security-Policy") // high severity, missing
+	url := headerServer(t, headers)
+
+	err := run([]string{"-fail-on", "high", url}, nil, io.Discard)
+	if !errors.Is(err, errFailThreshold) {
+		t.Errorf("run() with -fail-on high returned %v, want errFailThreshold", err)
+	}
+}
+
+func TestRunFailOnAlwaysFailsOnScanError(t *testing.T) {
+	// Nothing listens here, so the scan itself fails and produces a
+	// StatusError finding, which must fail regardless of severity.
+	err := run([]string{"-fail-on", "high", "http://127.0.0.1:1"}, nil, io.Discard)
+	if !errors.Is(err, errFailThreshold) {
+		t.Errorf("run() with an unreachable target returned %v, want errFailThreshold", err)
+	}
+}
+
+func TestRunFailOnNoneMatchesDefault(t *testing.T) {
+	url := headerServer(t, nil)
+	if err := run([]string{"-fail-on", "none", url}, nil, io.Discard); err != nil {
+		t.Errorf("run() with -fail-on none returned %v, want nil", err)
+	}
+}
+
+func TestRunRejectsInvalidFailOnFlag(t *testing.T) {
+	url := headerServer(t, strongHeaders())
+	err := run([]string{"-fail-on", "critical", url}, nil, io.Discard)
+	if err == nil {
+		t.Fatal("run() with -fail-on critical returned nil error, want error")
+	}
+	if errors.Is(err, errFailThreshold) {
+		t.Error("run() with -fail-on critical returned errFailThreshold, want a flag-parsing error")
+	}
+}
+
+func TestRunFailOnEnvVar(t *testing.T) {
+	url := headerServer(t, nil)
+	t.Setenv("MAMORI_FAIL_ON", "low")
+
+	err := run([]string{url}, nil, io.Discard)
+	if !errors.Is(err, errFailThreshold) {
+		t.Errorf("run() with MAMORI_FAIL_ON=low returned %v, want errFailThreshold", err)
+	}
+}
+
+func TestRunFailOnFlagOverridesEnvVar(t *testing.T) {
+	url := headerServer(t, nil)
+	t.Setenv("MAMORI_FAIL_ON", "low")
+
+	err := run([]string{"-fail-on", "none", url}, nil, io.Discard)
+	if err != nil {
+		t.Errorf("run() with -fail-on none overriding MAMORI_FAIL_ON=low returned %v, want nil", err)
+	}
+}

--- a/cmd/mamori/main_test.go
+++ b/cmd/mamori/main_test.go
@@ -38,6 +38,15 @@ func TestRunDefaultNeverFailsOnFindings(t *testing.T) {
 	}
 }
 
+func TestRunDefaultNeverFailsOnScanError(t *testing.T) {
+	// Nothing listens here, so the scan itself fails and produces a
+	// StatusError finding. Even that must not fail the run when -fail-on
+	// is unset, since "none" has to mean "never fail" unconditionally.
+	if err := run([]string{"http://127.0.0.1:1"}, nil, io.Discard); err != nil {
+		t.Errorf("run() with -fail-on unset returned %v, want nil for a scan error", err)
+	}
+}
+
 func TestRunFailOnMediumFailsOnMissingFindings(t *testing.T) {
 	url := headerServer(t, nil)
 	err := run([]string{"-fail-on", "medium", url}, nil, io.Discard)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	"github.com/PhyberApex/mamori/internal/scanner"
 )
 
 // Output is a named string type so the valid formats live next to the type
@@ -30,6 +32,10 @@ type Config struct {
 	Workers int
 	Timeout time.Duration
 	Output  Output
+	// FailOn is the -fail-on threshold. The zero value ("") is scanner.Severity's
+	// own stand-in for "none" — never fail — so Config's zero value is already
+	// the correct default without a separate sentinel constant.
+	FailOn scanner.Severity
 }
 
 func parseOutput(v string) (Output, error) {
@@ -83,11 +89,17 @@ func Resolve(args []string, getenv func(string) string) (Config, []string, error
 		}
 		cfg.Output = o
 	}
+	if v := getenv("MAMORI_FAIL_ON"); v != "" {
+		if err := cfg.FailOn.Set(v); err != nil {
+			return Config{}, nil, fmt.Errorf("MAMORI_FAIL_ON: %w", err)
+		}
+	}
 
 	fs := flag.NewFlagSet("mamori", flag.ContinueOnError)
 	fs.IntVar(&cfg.Workers, "workers", cfg.Workers, "number of concurrent scan workers")
 	fs.DurationVar(&cfg.Timeout, "timeout", cfg.Timeout, "HTTP request timeout (e.g. 5s)")
 	fs.Var(&cfg.Output, "o", "output format: terminal or json")
+	fs.Var(&cfg.FailOn, "fail-on", "exit non-zero on findings at or above this severity: low, medium, high, or none")
 	if err := fs.Parse(args); err != nil {
 		return Config{}, nil, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/PhyberApex/mamori/internal/config"
+	"github.com/PhyberApex/mamori/internal/scanner"
 )
 
 func noEnv(string) string { return "" }
@@ -30,6 +31,9 @@ func TestResolveDefaults(t *testing.T) {
 	if cfg.Output != config.OutputTerminal {
 		t.Errorf("Output = %q, want default %q", cfg.Output, config.OutputTerminal)
 	}
+	if cfg.FailOn != "" {
+		t.Errorf("FailOn = %q, want zero value (\"none\")", cfg.FailOn)
+	}
 }
 
 func TestResolveEnvOverridesDefaults(t *testing.T) {
@@ -37,6 +41,7 @@ func TestResolveEnvOverridesDefaults(t *testing.T) {
 		"MAMORI_WORKERS": "3",
 		"MAMORI_TIMEOUT": "2s",
 		"MAMORI_OUTPUT":  "json",
+		"MAMORI_FAIL_ON": "medium",
 	}))
 	if err != nil {
 		t.Fatalf("Resolve() returned error: %v", err)
@@ -50,15 +55,19 @@ func TestResolveEnvOverridesDefaults(t *testing.T) {
 	if cfg.Output != config.OutputJSON {
 		t.Errorf("Output = %q, want %q from MAMORI_OUTPUT", cfg.Output, config.OutputJSON)
 	}
+	if cfg.FailOn != scanner.SeverityMedium {
+		t.Errorf("FailOn = %q, want %q from MAMORI_FAIL_ON", cfg.FailOn, scanner.SeverityMedium)
+	}
 }
 
 func TestResolveFlagsOverrideEnv(t *testing.T) {
 	cfg, rest, err := config.Resolve(
-		[]string{"-workers", "5", "-timeout", "1s", "-o", "terminal", "https://a.example"},
+		[]string{"-workers", "5", "-timeout", "1s", "-o", "terminal", "-fail-on", "high", "https://a.example"},
 		envWith(map[string]string{
 			"MAMORI_WORKERS": "3",
 			"MAMORI_TIMEOUT": "2s",
 			"MAMORI_OUTPUT":  "json",
+			"MAMORI_FAIL_ON": "low",
 		}),
 	)
 	if err != nil {
@@ -72,6 +81,9 @@ func TestResolveFlagsOverrideEnv(t *testing.T) {
 	}
 	if cfg.Output != config.OutputTerminal {
 		t.Errorf("Output = %q, want %q from -o flag", cfg.Output, config.OutputTerminal)
+	}
+	if cfg.FailOn != scanner.SeverityHigh {
+		t.Errorf("FailOn = %q, want %q from -fail-on flag", cfg.FailOn, scanner.SeverityHigh)
 	}
 	if len(rest) != 1 || rest[0] != "https://a.example" {
 		t.Errorf("remaining args = %v, want [https://a.example]", rest)
@@ -89,6 +101,7 @@ func TestResolveRejectsInvalidEnvValues(t *testing.T) {
 		{"unparseable timeout", map[string]string{"MAMORI_TIMEOUT": "fast"}},
 		{"negative timeout", map[string]string{"MAMORI_TIMEOUT": "-1s"}},
 		{"unknown output format", map[string]string{"MAMORI_OUTPUT": "xml"}},
+		{"unknown fail-on level", map[string]string{"MAMORI_FAIL_ON": "critical"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -108,5 +121,24 @@ func TestResolveRejectsNonPositiveWorkersFlag(t *testing.T) {
 func TestResolveRejectsUnknownOutputFlag(t *testing.T) {
 	if _, _, err := config.Resolve([]string{"-o", "xml"}, noEnv); err == nil {
 		t.Error("Resolve() with -o xml returned nil error, want error")
+	}
+}
+
+func TestResolveRejectsUnknownFailOnFlag(t *testing.T) {
+	if _, _, err := config.Resolve([]string{"-fail-on", "critical"}, noEnv); err == nil {
+		t.Error("Resolve() with -fail-on critical returned nil error, want error")
+	}
+}
+
+func TestResolveFailOnNoneFlagOverridesEnv(t *testing.T) {
+	cfg, _, err := config.Resolve(
+		[]string{"-fail-on", "none"},
+		envWith(map[string]string{"MAMORI_FAIL_ON": "low"}),
+	)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.FailOn != "" {
+		t.Errorf("FailOn = %q, want zero value (\"none\") from -fail-on none", cfg.FailOn)
 	}
 }

--- a/internal/scanner/finding.go
+++ b/internal/scanner/finding.go
@@ -84,11 +84,18 @@ type Finding struct {
 }
 
 // Fails reports whether f should trip a -fail-on gate at the given
-// threshold. A StatusError always fails, regardless of threshold, since a
-// scan that couldn't complete shouldn't silently report success; a
+// threshold. The zero-value threshold ("none", per Severity.String) never
+// fails anything — that has to be enforced here rather than left to callers,
+// since "none" is Severity's own stand-in for "gate disabled" and every
+// caller of Fails/AnyFails needs that guarantee, not just -fail-on's current
+// call site. Otherwise a StatusError always fails, regardless of threshold,
+// since a scan that couldn't complete shouldn't silently report success; a
 // Missing/Weak finding fails once its severity reaches threshold; a Pass
 // never fails.
 func (f Finding) Fails(threshold Severity) bool {
+	if threshold == "" {
+		return false
+	}
 	if f.Status == StatusError {
 		return true
 	}

--- a/internal/scanner/finding.go
+++ b/internal/scanner/finding.go
@@ -1,5 +1,7 @@
 package scanner
 
+import "fmt"
+
 type Status string
 
 const (
@@ -21,6 +23,53 @@ const (
 	SeverityHigh   Severity = "high"
 )
 
+// severityRank gives each severity an ordinal so "at or above" comparisons
+// don't rely on string ordering — low < medium < high happens to sort
+// correctly as strings today, but that's a coincidence a future rename could
+// break silently.
+func severityRank(s Severity) int {
+	switch s {
+	case SeverityLow:
+		return 0
+	case SeverityMedium:
+		return 1
+	case SeverityHigh:
+		return 2
+	default:
+		return -1
+	}
+}
+
+// AtLeast reports whether s is at or above threshold in severity.
+func (s Severity) AtLeast(threshold Severity) bool {
+	return severityRank(s) >= severityRank(threshold)
+}
+
+// String and Set satisfy flag.Value directly on Severity — the same
+// validate-on-parse pattern config.Output uses for -o — so a flag like
+// -fail-on can take a Severity value without a parallel type wrapping this
+// one. The zero value stands for "no threshold" and round-trips as "none",
+// since Severity has no zero-value constant of its own.
+func (s *Severity) String() string {
+	if *s == "" {
+		return "none"
+	}
+	return string(*s)
+}
+
+func (s *Severity) Set(v string) error {
+	if v == "none" {
+		*s = ""
+		return nil
+	}
+	switch Severity(v) {
+	case SeverityLow, SeverityMedium, SeverityHigh:
+		*s = Severity(v)
+		return nil
+	}
+	return fmt.Errorf("%q is not a known severity (low, medium, high, or none)", v)
+}
+
 // The json struct tags pin the wire names independently of the Go field
 // names, so renaming a field during a refactor can never silently break
 // downstream jq pipelines. Without a tag, encoding/json would emit the
@@ -32,4 +81,29 @@ type Finding struct {
 	Severity  Severity `json:"severity"`
 	Reference string   `json:"reference"`
 	Message   string   `json:"message"`
+}
+
+// Fails reports whether f should trip a -fail-on gate at the given
+// threshold. A StatusError always fails, regardless of threshold, since a
+// scan that couldn't complete shouldn't silently report success; a
+// Missing/Weak finding fails once its severity reaches threshold; a Pass
+// never fails.
+func (f Finding) Fails(threshold Severity) bool {
+	if f.Status == StatusError {
+		return true
+	}
+	if f.Status != StatusMissing && f.Status != StatusWeak {
+		return false
+	}
+	return f.Severity.AtLeast(threshold)
+}
+
+// AnyFails reports whether any finding trips a -fail-on gate at threshold.
+func AnyFails(findings []Finding, threshold Severity) bool {
+	for _, f := range findings {
+		if f.Fails(threshold) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/scanner/finding_test.go
+++ b/internal/scanner/finding_test.go
@@ -136,6 +136,12 @@ func TestFindingFails(t *testing.T) {
 			threshold: scanner.SeverityHigh,
 			want:      true,
 		},
+		{
+			name:      "none threshold never fails, even a StatusError finding",
+			finding:   scanner.Finding{Status: scanner.StatusError, Severity: scanner.SeverityHigh},
+			threshold: scanner.Severity(""),
+			want:      false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/scanner/finding_test.go
+++ b/internal/scanner/finding_test.go
@@ -1,0 +1,147 @@
+package scanner_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/PhyberApex/mamori/internal/scanner"
+)
+
+// Severity must satisfy flag.Value so it can back a flag like -fail-on
+// directly, without a config-level wrapper type.
+var _ flag.Value = (*scanner.Severity)(nil)
+
+func TestSeverityAtLeast(t *testing.T) {
+	tests := []struct {
+		name      string
+		severity  scanner.Severity
+		threshold scanner.Severity
+		want      bool
+	}{
+		{"low at low", scanner.SeverityLow, scanner.SeverityLow, true},
+		{"low below medium", scanner.SeverityLow, scanner.SeverityMedium, false},
+		{"medium at medium", scanner.SeverityMedium, scanner.SeverityMedium, true},
+		{"high above medium", scanner.SeverityHigh, scanner.SeverityMedium, true},
+		{"medium below high", scanner.SeverityMedium, scanner.SeverityHigh, false},
+		{"high at high", scanner.SeverityHigh, scanner.SeverityHigh, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.severity.AtLeast(tt.threshold); got != tt.want {
+				t.Errorf("%s.AtLeast(%s) = %v, want %v", tt.severity, tt.threshold, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSeverityStringRoundTrip(t *testing.T) {
+	tests := []struct {
+		severity scanner.Severity
+		want     string
+	}{
+		{scanner.SeverityLow, "low"},
+		{scanner.SeverityMedium, "medium"},
+		{scanner.SeverityHigh, "high"},
+		{scanner.Severity(""), "none"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.severity.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSeveritySetValid(t *testing.T) {
+	tests := []struct {
+		input string
+		want  scanner.Severity
+	}{
+		{"low", scanner.SeverityLow},
+		{"medium", scanner.SeverityMedium},
+		{"high", scanner.SeverityHigh},
+		{"none", scanner.Severity("")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			var s scanner.Severity
+			if err := s.Set(tt.input); err != nil {
+				t.Fatalf("Set(%q) returned error: %v", tt.input, err)
+			}
+			if s != tt.want {
+				t.Errorf("Set(%q) = %q, want %q", tt.input, s, tt.want)
+			}
+		})
+	}
+}
+
+func TestSeveritySetRejectsUnknownValue(t *testing.T) {
+	var s scanner.Severity
+	if err := s.Set("critical"); err == nil {
+		t.Error("Set(\"critical\") returned nil error, want error")
+	}
+}
+
+func TestAnyFails(t *testing.T) {
+	findings := []scanner.Finding{
+		{Status: scanner.StatusPass, Severity: scanner.SeverityHigh},
+		{Status: scanner.StatusMissing, Severity: scanner.SeverityLow},
+	}
+	if scanner.AnyFails(findings, scanner.SeverityMedium) {
+		t.Error("AnyFails() = true, want false: only finding below threshold")
+	}
+	if !scanner.AnyFails(findings, scanner.SeverityLow) {
+		t.Error("AnyFails() = false, want true: low-severity missing finding at threshold")
+	}
+	if scanner.AnyFails(nil, scanner.SeverityLow) {
+		t.Error("AnyFails(nil, ...) = true, want false: no findings to trip the gate")
+	}
+}
+
+func TestFindingFails(t *testing.T) {
+	tests := []struct {
+		name      string
+		finding   scanner.Finding
+		threshold scanner.Severity
+		want      bool
+	}{
+		{
+			name:      "pass never fails",
+			finding:   scanner.Finding{Status: scanner.StatusPass, Severity: scanner.SeverityHigh},
+			threshold: scanner.SeverityLow,
+			want:      false,
+		},
+		{
+			name:      "missing below threshold does not fail",
+			finding:   scanner.Finding{Status: scanner.StatusMissing, Severity: scanner.SeverityMedium},
+			threshold: scanner.SeverityHigh,
+			want:      false,
+		},
+		{
+			name:      "missing at threshold fails",
+			finding:   scanner.Finding{Status: scanner.StatusMissing, Severity: scanner.SeverityMedium},
+			threshold: scanner.SeverityMedium,
+			want:      true,
+		},
+		{
+			name:      "weak above threshold fails",
+			finding:   scanner.Finding{Status: scanner.StatusWeak, Severity: scanner.SeverityHigh},
+			threshold: scanner.SeverityMedium,
+			want:      true,
+		},
+		{
+			name:      "error always fails regardless of severity",
+			finding:   scanner.Finding{Status: scanner.StatusError, Severity: scanner.SeverityLow},
+			threshold: scanner.SeverityHigh,
+			want:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.finding.Fails(tt.threshold); got != tt.want {
+				t.Errorf("Fails(%s) = %v, want %v", tt.threshold, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds a `-fail-on` flag (and matching `MAMORI_FAIL_ON` env var, following the existing default → env → flag precedence) that gates `mamori`'s exit code on scan findings:

- `-fail-on low|medium|high` — exit non-zero if any `missing`/`weak` finding is at or above that severity, or if any finding is `error` (a scan that couldn't complete always fails, regardless of threshold).
- `-fail-on none` (default) — unchanged behavior: always exit `0`.

`scanner.Severity` itself now implements `flag.Value` (`String()`/`Set()`, mirroring how `config.Output` does it for `-o`), with its zero value standing in for "no threshold." This reuses the existing `Severity` type and constants for `-fail-on` instead of introducing a parallel type, per the issue's guidance. A `severityRank` helper backs `Severity.AtLeast` so "at or above" comparisons don't rely on string ordering.

`Finding.Fails(threshold)` and `scanner.AnyFails(findings, threshold)` do the gating logic; `cmd/mamori/main.go`'s `run` returns a sentinel `errFailThreshold` when the gate trips, which `main()` special-cases (the same way it already special-cases `flag.ErrHelp`) to exit `1` without a redundant `mamori: ...` line — the report already printed has told the user what's wrong.

## Why

`mamori` always exited `0` on a successful scan regardless of findings, so a CI pipeline couldn't gate a build on a high-severity finding without a separate jq-and-exit-code wrapper.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` passes
- [x] `gofmt -l .` reports nothing
- New tests:
  - `internal/scanner/finding_test.go`: `Severity.AtLeast`, `Severity.String`/`Set` (including the `flag.Value` interface check), `Finding.Fails`, `scanner.AnyFails`
  - `internal/config/config_test.go`: `-fail-on`/`MAMORI_FAIL_ON` defaults, env override, flag-overrides-env, invalid value rejection, `-fail-on none` overriding a `MAMORI_FAIL_ON` env var
  - `cmd/mamori/main_test.go`: exit-code behavior end-to-end against `httptest` servers — default never fails, `-fail-on medium` fails on missing findings, `-fail-on high` ignores a medium-severity weak finding but fails on a high-severity missing one, an unreachable target's `error` finding always fails, env var and flag-overrides-env, invalid flag value

README's Flags/Environment variables tables and a new explanatory paragraph are updated.

Closes #29

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*