### PR TITLE
docs: drop the Go learning mode from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,3 @@
-## Go learning mode
-
-This project is being used to learn Go. During all implementation work:
-
-1. **Explain as you go** — when using a Go-specific concept (interfaces, goroutines, channels, defer, error wrapping, struct embedding, etc.), add a short "why we do it this way in Go" note inline. Skip basic syntax; focus on idiomatic choices and Go-specific patterns that would surprise someone coming from another language.
-
-2. **Quiz after each implementation** — end every implementation response with 2–3 quiz questions under a `## Quiz ✦` heading. Questions must:
-   - Require looking something up (`go doc`, the Go spec, or the Go blog) to answer confidently — not answerable from memory alone
-   - Test understanding of what was just built, not generic trivia
-   - Have **no answers given** — the user researches and can share answers back for feedback
-
 ## Agent skills
 
 ### Issue tracker


### PR DESCRIPTION
The learning-mode block bound *every* implementation session — including the autonomous karakuri Projects Runs, where the mandated quiz sections burn agent turns and the inline "why we do it this way in Go" notes can land as teaching comments in committed code. Go learning is no longer a current goal, so the agent guidance shrinks to the `## Agent skills` section.

No behavior change for the code itself; only agent instructions.

https://claude.ai/code/session_016Rc21cdVbEjD3BryTPkGWE