### PR TITLE
feat(config): add optional YAML config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ file merge additively with any targets passed as arguments or piped via
 stdin. Settings follow the same precedence as everything else: `default →
 config file → environment variable → CLI flag`.
 
+Because auto-discovery is silent, running mamori in an unfamiliar directory
+that contains a `.mamori.yaml` will pick up its settings and targets without
+being asked — review a directory's `.mamori.yaml` before scanning there if
+you don't already trust its contents.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Full reference for every check mamori performs is available at
 | `-timeout` | `10s` | HTTP request timeout (e.g. `5s`) |
 | `-o` | `terminal` | output format: `terminal` or `json` |
 | `-fail-on` | `none` | exit non-zero on findings at or above this severity: `low`, `medium`, `high`, or `none` |
+| `-config` | *(none)* | path to a YAML config file |
 
 `-o json` emits newline-delimited JSON, one finding per line.
 
@@ -90,6 +91,28 @@ precedence.
 | `MAMORI_TIMEOUT` | `-timeout` |
 | `MAMORI_OUTPUT` | `-o` |
 | `MAMORI_FAIL_ON` | `-fail-on` |
+| `MAMORI_CONFIG` | `-config` |
+
+### Config file
+
+Instead of passing flags and targets on every run, mamori can read them from
+a YAML config file:
+
+```yaml
+workers: 5
+timeout: 5s
+output: json
+targets:
+  - https://example.com
+  - https://example.org
+```
+
+Select a file explicitly with `-config <path>` or `MAMORI_CONFIG=<path>`. If
+neither is set, mamori looks for `.mamori.yaml` in the current directory and
+uses it if present — otherwise behavior is unchanged. Targets from the config
+file merge additively with any targets passed as arguments or piped via
+stdin. Settings follow the same precedence as everything else: `default →
+config file → environment variable → CLI flag`.
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/PhyberApex/mamori
 
 go 1.25.2
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,7 +67,10 @@ func (o *Output) Set(v string) error {
 // is validated by the one place that already knows what "known format"
 // means instead of a second string comparison growing elsewhere.
 func (o *Output) UnmarshalYAML(value *yaml.Node) error {
-	return o.Set(value.Value)
+	if err := o.Set(value.Value); err != nil {
+		return fmt.Errorf("output: %w", err)
+	}
+	return nil
 }
 
 // Resolve takes getenv as a function value instead of calling os.Getenv

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // Package config resolves runtime settings once at startup with the
-// precedence: hardcoded default → environment variable → CLI flag.
+// precedence: hardcoded default → config file → environment variable → CLI flag.
 package config
 
 import (
@@ -68,6 +68,11 @@ func (o *Output) Set(v string) error {
 func Resolve(args []string, getenv func(string) string) (Config, []string, error) {
 	cfg := Config{Workers: defaultWorkers, Timeout: defaultTimeout, Output: defaultOutput}
 
+	fileTargets, err := loadConfigLayer(&cfg, args, getenv)
+	if err != nil {
+		return Config{}, nil, err
+	}
+
 	if v := getenv("MAMORI_WORKERS"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 1 {
@@ -100,6 +105,11 @@ func Resolve(args []string, getenv func(string) string) (Config, []string, error
 	fs.DurationVar(&cfg.Timeout, "timeout", cfg.Timeout, "HTTP request timeout (e.g. 5s)")
 	fs.Var(&cfg.Output, "o", "output format: terminal or json")
 	fs.Var(&cfg.FailOn, "fail-on", "exit non-zero on findings at or above this severity: low, medium, high, or none")
+	// configPath is resolved and applied above, before the flag defaults are
+	// established; it is registered here purely so -config is recognized by
+	// Parse and documented in -h, not read back after Parse.
+	var configPath string
+	fs.StringVar(&configPath, "config", "", "path to YAML config file (env MAMORI_CONFIG; default: .mamori.yaml in the working directory if present)")
 	if err := fs.Parse(args); err != nil {
 		return Config{}, nil, err
 	}
@@ -109,5 +119,6 @@ func Resolve(args []string, getenv func(string) string) (Config, []string, error
 	if cfg.Timeout <= 0 {
 		return Config{}, nil, fmt.Errorf("-timeout: %v is not a positive duration", cfg.Timeout)
 	}
-	return cfg, fs.Args(), nil
+	targets := append(append([]string{}, fileTargets...), fs.Args()...)
+	return cfg, targets, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,10 +67,29 @@ func (o *Output) Set(v string) error {
 // is validated by the one place that already knows what "known format"
 // means instead of a second string comparison growing elsewhere.
 func (o *Output) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.ScalarNode {
+		return fmt.Errorf("output: must be a string, not %s", describeYAMLKind(value.Kind))
+	}
 	if err := o.Set(value.Value); err != nil {
 		return fmt.Errorf("output: %w", err)
 	}
 	return nil
+}
+
+// describeYAMLKind names a yaml.Node's Kind for the UnmarshalYAML error
+// message above, so a wrong-typed output value (e.g. a list) reports what
+// was actually found instead of being mistaken for an empty string.
+func describeYAMLKind(kind yaml.Kind) string {
+	switch kind {
+	case yaml.SequenceNode:
+		return "a list"
+	case yaml.MappingNode:
+		return "a mapping"
+	case yaml.AliasNode:
+		return "an alias"
+	default:
+		return "that value"
+	}
 }
 
 // validateWorkers reports whether n satisfies the "positive integer" rule

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/PhyberApex/mamori/internal/scanner"
+	"gopkg.in/yaml.v3"
 )
 
 // Output is a named string type so the valid formats live next to the type
@@ -59,6 +60,14 @@ func (o *Output) Set(v string) error {
 	}
 	*o = parsed
 	return nil
+}
+
+// UnmarshalYAML lets the config-file loader decode straight into an Output
+// via the same Set used by the flag package, so a config file's output value
+// is validated by the one place that already knows what "known format"
+// means instead of a second string comparison growing elsewhere.
+func (o *Output) UnmarshalYAML(value *yaml.Node) error {
+	return o.Set(value.Value)
 }
 
 // Resolve takes getenv as a function value instead of calling os.Getenv

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,44 @@ func (o *Output) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+// validateWorkers reports whether n satisfies the "positive integer" rule
+// the config-file, env, and flag layers all enforce for -workers.
+func validateWorkers(n int) error {
+	if n < 1 {
+		return fmt.Errorf("%d is not a positive integer", n)
+	}
+	return nil
+}
+
+// validateTimeout reports whether d satisfies the "positive duration" rule
+// the config-file, env, and flag layers all enforce for -timeout.
+func validateTimeout(d time.Duration) error {
+	if d <= 0 {
+		return fmt.Errorf("%v is not a positive duration", d)
+	}
+	return nil
+}
+
+// registerFlags builds the FlagSet mamori parses args with, wiring each flag
+// straight into cfg. The returned configPath pointer is populated by -config
+// but, in the real parse, resolveConfigPath's prescan has already resolved
+// and applied the config-file layer before this runs (see loadConfigLayer);
+// it is registered here purely so -config is recognized by Parse and
+// documented in -h. The prescan reuses this same registration so its parse
+// of -config agrees with the real parse on exactly where flag parsing stops
+// and on last-flag-wins for a repeated -config, instead of hand-rolling a
+// second, divergent parser.
+func registerFlags(cfg *Config) (*flag.FlagSet, *string) {
+	fs := flag.NewFlagSet("mamori", flag.ContinueOnError)
+	fs.IntVar(&cfg.Workers, "workers", cfg.Workers, "number of concurrent scan workers")
+	fs.DurationVar(&cfg.Timeout, "timeout", cfg.Timeout, "HTTP request timeout (e.g. 5s)")
+	fs.Var(&cfg.Output, "o", "output format: terminal or json")
+	fs.Var(&cfg.FailOn, "fail-on", "exit non-zero on findings at or above this severity: low, medium, high, or none")
+	var configPath string
+	fs.StringVar(&configPath, "config", "", "path to YAML config file (env MAMORI_CONFIG; default: .mamori.yaml in the working directory if present)")
+	return fs, &configPath
+}
+
 // Resolve takes getenv as a function value instead of calling os.Getenv
 // directly, so tests can inject environment values without mutating real
 // process state. The env-resolved values are used as the flag defaults,
@@ -87,14 +125,14 @@ func Resolve(args []string, getenv func(string) string) (Config, []string, error
 
 	if v := getenv("MAMORI_WORKERS"); v != "" {
 		n, err := strconv.Atoi(v)
-		if err != nil || n < 1 {
+		if err != nil || validateWorkers(n) != nil {
 			return Config{}, nil, fmt.Errorf("MAMORI_WORKERS: %q is not a positive integer", v)
 		}
 		cfg.Workers = n
 	}
 	if v := getenv("MAMORI_TIMEOUT"); v != "" {
 		d, err := time.ParseDuration(v)
-		if err != nil || d <= 0 {
+		if err != nil || validateTimeout(d) != nil {
 			return Config{}, nil, fmt.Errorf("MAMORI_TIMEOUT: %q is not a positive duration (e.g. 5s)", v)
 		}
 		cfg.Timeout = d
@@ -112,24 +150,15 @@ func Resolve(args []string, getenv func(string) string) (Config, []string, error
 		}
 	}
 
-	fs := flag.NewFlagSet("mamori", flag.ContinueOnError)
-	fs.IntVar(&cfg.Workers, "workers", cfg.Workers, "number of concurrent scan workers")
-	fs.DurationVar(&cfg.Timeout, "timeout", cfg.Timeout, "HTTP request timeout (e.g. 5s)")
-	fs.Var(&cfg.Output, "o", "output format: terminal or json")
-	fs.Var(&cfg.FailOn, "fail-on", "exit non-zero on findings at or above this severity: low, medium, high, or none")
-	// configPath is resolved and applied above, before the flag defaults are
-	// established; it is registered here purely so -config is recognized by
-	// Parse and documented in -h, not read back after Parse.
-	var configPath string
-	fs.StringVar(&configPath, "config", "", "path to YAML config file (env MAMORI_CONFIG; default: .mamori.yaml in the working directory if present)")
+	fs, _ := registerFlags(&cfg)
 	if err := fs.Parse(args); err != nil {
 		return Config{}, nil, err
 	}
-	if cfg.Workers < 1 {
-		return Config{}, nil, fmt.Errorf("-workers: %d is not a positive integer", cfg.Workers)
+	if err := validateWorkers(cfg.Workers); err != nil {
+		return Config{}, nil, fmt.Errorf("-workers: %w", err)
 	}
-	if cfg.Timeout <= 0 {
-		return Config{}, nil, fmt.Errorf("-timeout: %v is not a positive duration", cfg.Timeout)
+	if err := validateTimeout(cfg.Timeout); err != nil {
+		return Config{}, nil, fmt.Errorf("-timeout: %w", err)
 	}
 	targets := append(append([]string{}, fileTargets...), fs.Args()...)
 	return cfg, targets, nil

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// autoDiscoverPath is the config file mamori looks for in the working
+// directory when neither -config nor MAMORI_CONFIG names one explicitly.
+const autoDiscoverPath = ".mamori.yaml"
+
+// fileConfig mirrors the subset of Config a YAML config file may set. Fields
+// are pointers so the loader can tell "absent" apart from "explicitly zero"
+// and only override what the file actually sets.
+type fileConfig struct {
+	Targets []string `yaml:"targets"`
+	Workers *int     `yaml:"workers"`
+	Timeout *string  `yaml:"timeout"`
+	Output  *string  `yaml:"output"`
+}
+
+// resolveConfigPath decides which config file, if any, supplies the config
+// layer. An explicit -config flag or MAMORI_CONFIG env var must name a file
+// that exists — checked by the caller when it loads the file — while the
+// .mamori.yaml auto-discovery path is allowed to not exist, since absence
+// there just means "no config file" rather than a misconfiguration.
+func resolveConfigPath(args []string, getenv func(string) string) (path string, explicit bool) {
+	if v := prescanConfigFlag(args); v != "" {
+		return v, true
+	}
+	if v := getenv("MAMORI_CONFIG"); v != "" {
+		return v, true
+	}
+	return autoDiscoverPath, false
+}
+
+// prescanConfigFlag looks for -config/--config ahead of the full flag.Parse
+// call in Resolve: the config file has to be loaded before it can seed the
+// flag defaults that establish the default → config → env → flag precedence.
+// A malformed -config usage (e.g. a missing value) is left for flag.Parse to
+// reject with its usual error rather than being handled here.
+func prescanConfigFlag(args []string) string {
+	for i, arg := range args {
+		switch {
+		case arg == "-config" || arg == "--config":
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+		case strings.HasPrefix(arg, "-config="):
+			return strings.TrimPrefix(arg, "-config=")
+		case strings.HasPrefix(arg, "--config="):
+			return strings.TrimPrefix(arg, "--config=")
+		}
+	}
+	return ""
+}
+
+func loadConfigFile(path string) (fileConfig, error) {
+	//nolint:gosec // G304 false positive: path is the user's own -config/MAMORI_CONFIG/.mamori.yaml selection, not attacker-controlled input
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fileConfig{}, err
+	}
+	var fc fileConfig
+	if err := yaml.Unmarshal(data, &fc); err != nil {
+		return fileConfig{}, fmt.Errorf("%s: %w", path, err)
+	}
+	return fc, nil
+}
+
+// applyFileConfig overrides cfg with any fields fc sets, validating with the
+// same rules the env and flag stages already enforce so a bad config file
+// fails the same way a bad env var or flag would.
+func applyFileConfig(cfg *Config, fc fileConfig, path string) error {
+	if fc.Workers != nil {
+		if *fc.Workers < 1 {
+			return fmt.Errorf("%s: workers: %d is not a positive integer", path, *fc.Workers)
+		}
+		cfg.Workers = *fc.Workers
+	}
+	if fc.Timeout != nil {
+		d, err := time.ParseDuration(*fc.Timeout)
+		if err != nil || d <= 0 {
+			return fmt.Errorf("%s: timeout: %q is not a positive duration (e.g. 5s)", path, *fc.Timeout)
+		}
+		cfg.Timeout = d
+	}
+	if fc.Output != nil {
+		o, err := parseOutput(*fc.Output)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		cfg.Output = o
+	}
+	return nil
+}
+
+// loadConfigLayer resolves and applies the config-file layer onto cfg,
+// returning any targets the file declares. It is a no-op, without error,
+// when auto-discovery finds nothing — explicit selection via -config or
+// MAMORI_CONFIG must resolve to a real, valid file.
+func loadConfigLayer(cfg *Config, args []string, getenv func(string) string) ([]string, error) {
+	path, explicit := resolveConfigPath(args, getenv)
+	fc, err := loadConfigFile(path)
+	switch {
+	case err == nil:
+		if err := applyFileConfig(cfg, fc, path); err != nil {
+			return nil, err
+		}
+		return fc.Targets, nil
+	case explicit:
+		return nil, fmt.Errorf("config: %w", err)
+	case errors.Is(err, os.ErrNotExist):
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("config: %w", err)
+	}
+}

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -21,7 +21,7 @@ type fileConfig struct {
 	Targets []string `yaml:"targets"`
 	Workers *int     `yaml:"workers"`
 	Timeout *string  `yaml:"timeout"`
-	Output  *string  `yaml:"output"`
+	Output  *Output  `yaml:"output"`
 }
 
 // resolveConfigPath decides which config file, if any, supplies the config
@@ -91,11 +91,7 @@ func applyFileConfig(cfg *Config, fc fileConfig, path string) error {
 		cfg.Timeout = d
 	}
 	if fc.Output != nil {
-		o, err := parseOutput(*fc.Output)
-		if err != nil {
-			return fmt.Errorf("%s: %w", path, err)
-		}
-		cfg.Output = o
+		cfg.Output = *fc.Output
 	}
 	return nil
 }

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -3,8 +3,8 @@ package config
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
-	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -39,25 +39,22 @@ func resolveConfigPath(args []string, getenv func(string) string) (path string, 
 	return autoDiscoverPath, false
 }
 
-// prescanConfigFlag looks for -config/--config ahead of the full flag.Parse
-// call in Resolve: the config file has to be loaded before it can seed the
-// flag defaults that establish the default → config → env → flag precedence.
-// A malformed -config usage (e.g. a missing value) is left for flag.Parse to
-// reject with its usual error rather than being handled here.
+// prescanConfigFlag looks for -config ahead of the full flag.Parse call in
+// Resolve: the config file has to be loaded before it can seed the flag
+// defaults that establish the default → config → env → flag precedence. It
+// parses with the same registerFlags definitions the real parse uses, so
+// this prescan agrees with flag.Parse on exactly where flag parsing stops
+// (e.g. at the first positional target argument) and on last-flag-wins for
+// a repeated -config, rather than a hand-rolled scan that could disagree
+// with flag.Parse about which -config occurrence, if any, applies. A
+// malformed usage is left for the real Parse call to reject with its usual
+// error rather than being handled here.
 func prescanConfigFlag(args []string) string {
-	for i, arg := range args {
-		switch {
-		case arg == "-config" || arg == "--config":
-			if i+1 < len(args) {
-				return args[i+1]
-			}
-		case strings.HasPrefix(arg, "-config="):
-			return strings.TrimPrefix(arg, "-config=")
-		case strings.HasPrefix(arg, "--config="):
-			return strings.TrimPrefix(arg, "--config=")
-		}
-	}
-	return ""
+	var cfg Config
+	fs, configPath := registerFlags(&cfg)
+	fs.SetOutput(io.Discard)
+	_ = fs.Parse(args)
+	return *configPath
 }
 
 func loadConfigFile(path string) (fileConfig, error) {
@@ -78,14 +75,14 @@ func loadConfigFile(path string) (fileConfig, error) {
 // fails the same way a bad env var or flag would.
 func applyFileConfig(cfg *Config, fc fileConfig, path string) error {
 	if fc.Workers != nil {
-		if *fc.Workers < 1 {
-			return fmt.Errorf("%s: workers: %d is not a positive integer", path, *fc.Workers)
+		if err := validateWorkers(*fc.Workers); err != nil {
+			return fmt.Errorf("%s: workers: %w", path, err)
 		}
 		cfg.Workers = *fc.Workers
 	}
 	if fc.Timeout != nil {
 		d, err := time.ParseDuration(*fc.Timeout)
-		if err != nil || d <= 0 {
+		if err != nil || validateTimeout(d) != nil {
 			return fmt.Errorf("%s: timeout: %q is not a positive duration (e.g. 5s)", path, *fc.Timeout)
 		}
 		cfg.Timeout = d

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -1,0 +1,205 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/PhyberApex/mamori/internal/config"
+)
+
+func writeConfigFile(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+	return path
+}
+
+func TestResolveConfigFlagLoadsWorkersTimeoutOutputAndTargets(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", `
+workers: 4
+timeout: 3s
+output: json
+targets:
+  - https://from-config.example
+`)
+
+	cfg, targets, err := config.Resolve([]string{"-config", path}, noEnv)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.Workers != 4 {
+		t.Errorf("Workers = %d, want 4 from config file", cfg.Workers)
+	}
+	if cfg.Timeout != 3*time.Second {
+		t.Errorf("Timeout = %v, want 3s from config file", cfg.Timeout)
+	}
+	if cfg.Output != config.OutputJSON {
+		t.Errorf("Output = %q, want %q from config file", cfg.Output, config.OutputJSON)
+	}
+	if len(targets) != 1 || targets[0] != "https://from-config.example" {
+		t.Errorf("targets = %v, want [https://from-config.example]", targets)
+	}
+}
+
+func TestResolveConfigEnvVarSelectsFile(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", `workers: 7`)
+
+	cfg, _, err := config.Resolve(nil, envWith(map[string]string{"MAMORI_CONFIG": path}))
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.Workers != 7 {
+		t.Errorf("Workers = %d, want 7 from MAMORI_CONFIG file", cfg.Workers)
+	}
+}
+
+func TestResolveConfigFlagOverridesConfigEnvVar(t *testing.T) {
+	flagPath := writeConfigFile(t, t.TempDir(), "flag.yaml", `workers: 5`)
+	envPath := writeConfigFile(t, t.TempDir(), "env.yaml", `workers: 9`)
+
+	cfg, _, err := config.Resolve(
+		[]string{"-config", flagPath},
+		envWith(map[string]string{"MAMORI_CONFIG": envPath}),
+	)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.Workers != 5 {
+		t.Errorf("Workers = %d, want 5 from -config flag overriding MAMORI_CONFIG", cfg.Workers)
+	}
+}
+
+func TestResolveEnvVarOverridesConfigFile(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", `workers: 3`)
+
+	cfg, _, err := config.Resolve(
+		[]string{"-config", path},
+		envWith(map[string]string{"MAMORI_WORKERS": "8"}),
+	)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.Workers != 8 {
+		t.Errorf("Workers = %d, want 8 from MAMORI_WORKERS overriding config file", cfg.Workers)
+	}
+}
+
+func TestResolveFlagOverridesConfigFile(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", `workers: 3`)
+
+	cfg, _, err := config.Resolve([]string{"-config", path, "-workers", "6"}, noEnv)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.Workers != 6 {
+		t.Errorf("Workers = %d, want 6 from -workers flag overriding config file", cfg.Workers)
+	}
+}
+
+func TestResolveConfigFileTargetsMergeAdditivelyWithArgs(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", `
+targets:
+  - https://from-config.example
+`)
+
+	_, targets, err := config.Resolve([]string{"-config", path, "https://from-args.example"}, noEnv)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	want := map[string]bool{"https://from-config.example": true, "https://from-args.example": true}
+	if len(targets) != len(want) {
+		t.Fatalf("targets = %v, want two entries", targets)
+	}
+	for _, target := range targets {
+		if !want[target] {
+			t.Errorf("unexpected target %q", target)
+		}
+	}
+}
+
+func TestResolveMissingExplicitConfigFlagErrors(t *testing.T) {
+	if _, _, err := config.Resolve([]string{"-config", filepath.Join(t.TempDir(), "missing.yaml")}, noEnv); err == nil {
+		t.Error("Resolve() with a missing -config path returned nil error, want error")
+	}
+}
+
+func TestResolveMissingExplicitConfigEnvVarErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.yaml")
+	if _, _, err := config.Resolve(nil, envWith(map[string]string{"MAMORI_CONFIG": path})); err == nil {
+		t.Error("Resolve() with a missing MAMORI_CONFIG path returned nil error, want error")
+	}
+}
+
+func TestResolveConfigFileRejectsNonPositiveWorkers(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", `workers: 0`)
+	if _, _, err := config.Resolve([]string{"-config", path}, noEnv); err == nil {
+		t.Error("Resolve() with workers: 0 in config file returned nil error, want error")
+	}
+}
+
+func TestResolveConfigFileRejectsNonPositiveTimeout(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", `timeout: -1s`)
+	if _, _, err := config.Resolve([]string{"-config", path}, noEnv); err == nil {
+		t.Error("Resolve() with a negative timeout in config file returned nil error, want error")
+	}
+}
+
+func TestResolveConfigFileRejectsUnknownOutput(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", `output: xml`)
+	if _, _, err := config.Resolve([]string{"-config", path}, noEnv); err == nil {
+		t.Error("Resolve() with an unknown output format in config file returned nil error, want error")
+	}
+}
+
+func TestResolveConfigFileRejectsInvalidYAML(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", "workers: [this is not an int\n")
+	if _, _, err := config.Resolve([]string{"-config", path}, noEnv); err == nil {
+		t.Error("Resolve() with malformed YAML in config file returned nil error, want error")
+	}
+}
+
+func TestResolveAutoDiscoversDotMamoriYAMLInWorkingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeConfigFile(t, dir, ".mamori.yaml", `
+workers: 2
+targets:
+  - https://auto.example
+`)
+	t.Chdir(dir)
+
+	cfg, targets, err := config.Resolve(nil, noEnv)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.Workers != 2 {
+		t.Errorf("Workers = %d, want 2 from auto-discovered .mamori.yaml", cfg.Workers)
+	}
+	if len(targets) != 1 || targets[0] != "https://auto.example" {
+		t.Errorf("targets = %v, want [https://auto.example]", targets)
+	}
+}
+
+func TestResolveWithNoConfigFilePresentIsUnchanged(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	cfg, rest, err := config.Resolve([]string{"https://a.example"}, noEnv)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.Workers != 10 {
+		t.Errorf("Workers = %d, want default 10 with no config file present", cfg.Workers)
+	}
+	if cfg.Timeout != 10*time.Second {
+		t.Errorf("Timeout = %v, want default 10s with no config file present", cfg.Timeout)
+	}
+	if cfg.Output != config.OutputTerminal {
+		t.Errorf("Output = %q, want default %q with no config file present", cfg.Output, config.OutputTerminal)
+	}
+	if len(rest) != 1 || rest[0] != "https://a.example" {
+		t.Errorf("targets = %v, want [https://a.example]", rest)
+	}
+}

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -121,6 +121,42 @@ targets:
 	}
 }
 
+func TestResolveConfigFlagLastOccurrenceWins(t *testing.T) {
+	first := writeConfigFile(t, t.TempDir(), "first.yaml", `workers: 3`)
+	second := writeConfigFile(t, t.TempDir(), "second.yaml", `workers: 9`)
+
+	cfg, _, err := config.Resolve([]string{"-config", first, "-config", second}, noEnv)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.Workers != 9 {
+		t.Errorf("Workers = %d, want 9 from the second -config (last occurrence wins, matching flag.Parse's normal repeated-flag semantics)", cfg.Workers)
+	}
+}
+
+func TestResolveConfigFlagAfterPositionalArgIsNotRecognized(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	path := writeConfigFile(t, dir, "should-not-load.yaml", `workers: 99`)
+
+	cfg, targets, err := config.Resolve([]string{"https://example.com", "-config", path}, noEnv)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.Workers != 10 {
+		t.Errorf("Workers = %d, want default 10: flag.Parse stops at the first positional argument, so -config after https://example.com is never reached and must not be treated as an explicit -config selection", cfg.Workers)
+	}
+	found := false
+	for _, target := range targets {
+		if target == "https://example.com" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("targets = %v, want https://example.com among them", targets)
+	}
+}
+
 func TestResolveMissingExplicitConfigFlagErrors(t *testing.T) {
 	if _, _, err := config.Resolve([]string{"-config", filepath.Join(t.TempDir(), "missing.yaml")}, noEnv); err == nil {
 		t.Error("Resolve() with a missing -config path returned nil error, want error")

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -188,6 +189,17 @@ func TestResolveConfigFileRejectsUnknownOutput(t *testing.T) {
 	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", `output: xml`)
 	if _, _, err := config.Resolve([]string{"-config", path}, noEnv); err == nil {
 		t.Error("Resolve() with an unknown output format in config file returned nil error, want error")
+	}
+}
+
+func TestResolveConfigFileRejectsNonScalarOutput(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", "output: [terminal, json]\n")
+	_, _, err := config.Resolve([]string{"-config", path}, noEnv)
+	if err == nil {
+		t.Fatal("Resolve() with a non-scalar output in config file returned nil error, want error")
+	}
+	if strings.Contains(err.Error(), `""`) {
+		t.Errorf("Resolve() error = %q, want it to describe the list rather than an empty string", err.Error())
 	}
 }
 


### PR DESCRIPTION
## What

Adds optional YAML config file support so targets and settings don't need to be passed via flags/stdin on every run:

- `-config <path>` flag or `MAMORI_CONFIG` env var select a file explicitly; when neither is set, mamori auto-discovers `.mamori.yaml` in the working directory and uses it if present (absence is not an error — behavior is unchanged from today).
- The config file may set `workers`, `timeout`, `output`, and `targets`, validated with the same rules already enforced for flags/env.
- Precedence is now `default → config file → env var → CLI flag`, each stage overriding the previous when set.
- Config-file targets merge additively with CLI-arg/stdin targets, mirroring how args+stdin already merge.
- Introduces `gopkg.in/yaml.v3` as the project's first third-party dependency.

## Why

Issue #30: passing every target and flag on every invocation is tedious for repeat scans against the same set of endpoints.

## Test evidence

- New tests in `internal/config/file_test.go` cover: explicit `-config`, `MAMORI_CONFIG`, precedence at every layer (config < env < flag), additive target merging, missing-explicit-file errors, invalid workers/timeout/output validation, malformed YAML, `.mamori.yaml` auto-discovery, and a regression test proving behavior is unchanged with no config file present.
- `go build ./...`, `go vet ./...`, `gofmt -l .`, and `golangci-lint run ./...` all clean.
- `go test ./...` passes (all packages).
- Manual smoke test: verified `-config`, `MAMORI_CONFIG`, `.mamori.yaml` auto-discovery, target merging with CLI args, and error output for a missing explicit config file and an invalid `output` value in a config file.
- Ran `/code-review` (Standards + Spec axes) against `origin/main`; addressed the one actionable Standards finding (config-file `output` now decodes through `Output`'s own `Set`/`flag.Value` path instead of a second raw-string parse site).

Closes #30

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*