### PR TITLE
feat(scanner): add Permissions-Policy checker

### DIFF
--- a/cmd/mamori/main_test.go
+++ b/cmd/mamori/main_test.go
@@ -17,6 +17,7 @@ func strongHeaders() map[string]string {
 		"X-Frame-Options":           "DENY",
 		"Content-Security-Policy":   "default-src 'self'",
 		"Referrer-Policy":           "strict-origin-when-cross-origin",
+		"Permissions-Policy":        "geolocation=()",
 	}
 }
 

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -19,6 +19,7 @@ func DefaultCheckers() []Checker {
 		CSPChecker{},
 		ReferrerPolicyChecker{},
 		CookieChecker{},
+		PermissionsPolicyChecker{},
 	}
 }
 
@@ -173,6 +174,17 @@ func effectiveReferrerPolicy(value string) string {
 		}
 	}
 	return effective
+}
+
+type PermissionsPolicyChecker struct{}
+
+func (PermissionsPolicyChecker) Check(headers http.Header) []Finding {
+	return checkPresence(
+		headers,
+		"Permissions-Policy",
+		SeverityMedium,
+		"https://owasp.org/www-project-secure-headers/#permissions-policy",
+	)
 }
 
 const cookieReference = "https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html"

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -176,17 +176,6 @@ func effectiveReferrerPolicy(value string) string {
 	return effective
 }
 
-type PermissionsPolicyChecker struct{}
-
-func (PermissionsPolicyChecker) Check(headers http.Header) []Finding {
-	return checkPresence(
-		headers,
-		"Permissions-Policy",
-		SeverityMedium,
-		"https://owasp.org/www-project-secure-headers/#permissions-policy",
-	)
-}
-
 const cookieReference = "https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html"
 
 // CookieChecker inspects every Set-Cookie header for the three flags that
@@ -245,6 +234,17 @@ func cookieFindings(cookie *http.Cookie) []Finding {
 		})
 	}
 	return findings
+}
+
+type PermissionsPolicyChecker struct{}
+
+func (PermissionsPolicyChecker) Check(headers http.Header) []Finding {
+	return checkPresence(
+		headers,
+		"Permissions-Policy",
+		SeverityMedium,
+		"https://owasp.org/www-project-secure-headers/#permissions-policy",
+	)
 }
 
 func checkPresence(headers http.Header, name string, severity Severity, reference string) []Finding {

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -20,6 +20,7 @@ func TestCheckersIdentity(t *testing.T) {
 		{scanner.FrameOptionsChecker{}, "X-Frame-Options", scanner.SeverityMedium, "DENY"},
 		{scanner.CSPChecker{}, "Content-Security-Policy", scanner.SeverityHigh, "default-src 'self'"},
 		{scanner.ReferrerPolicyChecker{}, "Referrer-Policy", scanner.SeverityLow, "strict-origin-when-cross-origin"},
+		{scanner.PermissionsPolicyChecker{}, "Permissions-Policy", scanner.SeverityMedium, "geolocation=()"},
 	}
 
 	for _, tt := range tests {

--- a/internal/scanner/runall_test.go
+++ b/internal/scanner/runall_test.go
@@ -27,6 +27,7 @@ func TestRunAllFansOutAcrossDefaultCheckers(t *testing.T) {
 		"X-Frame-Options":           scanner.StatusMissing,
 		"Content-Security-Policy":   scanner.StatusPass,
 		"Referrer-Policy":           scanner.StatusMissing,
+		"Permissions-Policy":        scanner.StatusMissing,
 	}
 	if len(findings) != len(want) {
 		t.Fatalf("RunAll() returned %d findings, want %d", len(findings), len(want))

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -17,6 +17,7 @@ var allSecurityHeaders = map[string]string{
 	"X-Frame-Options":           "DENY",
 	"Content-Security-Policy":   "default-src 'self'",
 	"Referrer-Policy":           "no-referrer",
+	"Permissions-Policy":        "geolocation=()",
 }
 
 func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
@@ -25,8 +26,8 @@ func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
 	t.Cleanup(srv.Close)
 
 	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), []string{srv.URL}, 1)
-	if len(findings) != 5 {
-		t.Fatalf("Scan() returned %d findings, want 5", len(findings))
+	if len(findings) != 6 {
+		t.Fatalf("Scan() returned %d findings, want 6", len(findings))
 	}
 	for _, f := range findings {
 		if f.URL != srv.URL {
@@ -79,8 +80,8 @@ func TestScanCoversMultipleURLs(t *testing.T) {
 	t.Cleanup(srvB.Close)
 
 	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), []string{srvA.URL, srvB.URL}, 2)
-	if len(findings) != 10 {
-		t.Fatalf("Scan() returned %d findings, want 10 (5 per URL)", len(findings))
+	if len(findings) != 12 {
+		t.Fatalf("Scan() returned %d findings, want 12 (6 per URL)", len(findings))
 	}
 }
 
@@ -145,8 +146,8 @@ func TestScanReportsAllTargetsDespiteFailures(t *testing.T) {
 	if got := len(byURL[deadURL]); got != 1 {
 		t.Errorf("dead target has %d findings, want 1 error finding", got)
 	}
-	if got := len(byURL[healthy.URL]); got != 5 {
-		t.Errorf("healthy target has %d findings, want 5", got)
+	if got := len(byURL[healthy.URL]); got != 6 {
+		t.Errorf("healthy target has %d findings, want 6", got)
 	}
 }
 
@@ -165,8 +166,8 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), urls, targets)
 
 	assertAllStatus(t, findings, scanner.StatusMissing)
-	if len(findings) != targets*5 {
-		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*5)
+	if len(findings) != targets*6 {
+		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*6)
 	}
 }
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -11,3 +11,4 @@ header_pages:
   - checks/content-security-policy.md
   - checks/referrer-policy.md
   - checks/set-cookie.md
+  - checks/permissions-policy.md

--- a/site/checks/permissions-policy.md
+++ b/site/checks/permissions-policy.md
@@ -1,0 +1,30 @@
+---
+layout: page
+title: Permissions-Policy
+permalink: /checks/permissions-policy
+---
+
+**Severity:** medium
+
+## What it does
+
+Lets a site opt in or out of powerful browser features (camera, microphone, geolocation, etc.) for itself and any content it embeds. Without it, embedded third-party content can use these features unless the browser's own defaults happen to block them.
+
+## Expected value
+
+Permissions-Policy values are application-specific. A restrictive starting point:
+
+```
+Permissions-Policy: geolocation=(), camera=(), microphone=()
+```
+
+This denies these features to the page and any iframes it embeds. Most apps need to expand this to allow the features they actually use.
+
+## What mamori checks
+
+Presence of the header. A missing header is reported as a medium-severity finding. mamori does not validate the Permissions-Policy value — that requires understanding which features your application actually needs.
+
+## Further reading
+
+- [MDN: Permissions-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy)
+- [OWASP: Secure Headers Project](https://owasp.org/www-project-secure-headers/#permissions-policy)

--- a/site/index.md
+++ b/site/index.md
@@ -15,3 +15,4 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `Content-Security-Policy` | high | [docs](checks/content-security-policy) |
 | `Referrer-Policy` | low | [docs](checks/referrer-policy) |
 | `Set-Cookie` | high / medium | [docs](checks/set-cookie) |
+| `Permissions-Policy` | medium | [docs](checks/permissions-policy) |


### PR DESCRIPTION
## What

Adds `PermissionsPolicyChecker`, a presence-only check for the `Permissions-Policy` header, mirroring the existing `CSPChecker` pattern (`checkPresence`). A missing or empty header is reported as `StatusMissing` at medium severity, with a reference to OWASP's Secure Headers guidance.

## Why

`Permissions-Policy` lets a site opt out powerful browser features (camera, geolocation, etc.) for itself and any embedded content; mamori didn't flag its absence yet.

## Changes

- `internal/scanner/checkers.go`: new `PermissionsPolicyChecker`, registered in `DefaultCheckers()`, declared after `CookieChecker` to match registration order (per code review below).
- Test updates across `checkers_test.go`, `runall_test.go`, `scan_test.go`, `cmd/mamori/main_test.go` to account for the new checker.
- `site/checks/permissions-policy.md` + `site/_config.yml` + `site/index.md`: doc-site entry, following the precedent set by the Set-Cookie checker addition.

## Test evidence

```
go build ./...
go vet ./...
gofmt -l .          # no output
go test ./...        # ok for all 3 packages
```

Ran `/mattpocock-skills:code-review` against `origin/main` (two parallel axes):
- **Spec**: no missing/partial requirements, no scope creep, no wrong-implementation findings.
- **Standards**: one ordering mismatch found and fixed (checker declaration order now matches `DefaultCheckers()` registration order).

Closes #37

---
*Opened by Kongroo, karakuri's Projects agent — Stage: implement*