### PR TITLE
feat(scanner): add Cross-Origin-Opener-Policy checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A concurrent API security scanner built in Go
 
 `mamori` scans one or more HTTP(S) endpoints for missing or misconfigured
 security headers (HSTS, CSP, `X-Frame-Options`, `X-Content-Type-Options`,
-`Referrer-Policy`) and reports the findings, with each missing header linked
-to guidance on how to fix it.
+`Referrer-Policy`, `Cross-Origin-Opener-Policy`) and reports the findings,
+with each missing header linked to guidance on how to fix it.
 
 ## Install
 
@@ -54,6 +54,7 @@ https://example.com
   [MISSING] X-Frame-Options (medium) → https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html
   [MISSING] Content-Security-Policy (high) → https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
   [MISSING] Referrer-Policy (low) → https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#referrer-policy
+  [MISSING] Cross-Origin-Opener-Policy (medium) → https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
 ```
 
 Full reference for every check mamori performs is available at

--- a/cmd/mamori/main_test.go
+++ b/cmd/mamori/main_test.go
@@ -12,11 +12,12 @@ import (
 // server built from this map alone never trips -fail-on at any severity.
 func strongHeaders() map[string]string {
 	return map[string]string{
-		"Strict-Transport-Security": "max-age=63072000; includeSubDomains",
-		"X-Content-Type-Options":    "nosniff",
-		"X-Frame-Options":           "DENY",
-		"Content-Security-Policy":   "default-src 'self'",
-		"Referrer-Policy":           "strict-origin-when-cross-origin",
+		"Strict-Transport-Security":  "max-age=63072000; includeSubDomains",
+		"X-Content-Type-Options":     "nosniff",
+		"X-Frame-Options":            "DENY",
+		"Content-Security-Policy":    "default-src 'self'",
+		"Referrer-Policy":            "strict-origin-when-cross-origin",
+		"Cross-Origin-Opener-Policy": "same-origin",
 	}
 }
 

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -18,6 +18,7 @@ func DefaultCheckers() []Checker {
 		FrameOptionsChecker{},
 		CSPChecker{},
 		ReferrerPolicyChecker{},
+		COOPChecker{},
 		CookieChecker{},
 	}
 }
@@ -173,6 +174,30 @@ func effectiveReferrerPolicy(value string) string {
 		}
 	}
 	return effective
+}
+
+type COOPChecker struct{}
+
+func (COOPChecker) Check(headers http.Header) []Finding {
+	return checkValue(
+		headers,
+		"Cross-Origin-Opener-Policy",
+		SeverityMedium,
+		"https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy",
+		coopWeakness,
+	)
+}
+
+// coopWeakness flags unsafe-none, the spec's default, and any unrecognized
+// value: both leave the page unisolated, sharing its browsing context group
+// with cross-origin popups/openers. same-origin-allow-popups and
+// same-origin are both accepted, since either provides real isolation.
+func coopWeakness(value string) (weak bool, message string) {
+	trimmed := strings.TrimSpace(value)
+	if strings.EqualFold(trimmed, "same-origin") || strings.EqualFold(trimmed, "same-origin-allow-popups") {
+		return false, ""
+	}
+	return true, fmt.Sprintf("%q does not isolate the browsing context from cross-origin popups/openers", value)
 }
 
 const cookieReference = "https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html"

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -20,6 +20,7 @@ func TestCheckersIdentity(t *testing.T) {
 		{scanner.FrameOptionsChecker{}, "X-Frame-Options", scanner.SeverityMedium, "DENY"},
 		{scanner.CSPChecker{}, "Content-Security-Policy", scanner.SeverityHigh, "default-src 'self'"},
 		{scanner.ReferrerPolicyChecker{}, "Referrer-Policy", scanner.SeverityLow, "strict-origin-when-cross-origin"},
+		{scanner.COOPChecker{}, "Cross-Origin-Opener-Policy", scanner.SeverityMedium, "same-origin"},
 	}
 
 	for _, tt := range tests {
@@ -127,6 +128,7 @@ func TestCheckValueIgnoresBlankDuplicateOccurrence(t *testing.T) {
 		{"ContentTypeOptions", scanner.ContentTypeOptionsChecker{}, http.Header{"X-Content-Type-Options": {"nosniff", ""}}},
 		{"FrameOptions", scanner.FrameOptionsChecker{}, http.Header{"X-Frame-Options": {"DENY", ""}}},
 		{"ReferrerPolicy", scanner.ReferrerPolicyChecker{}, http.Header{"Referrer-Policy": {"strict-origin-when-cross-origin", ""}}},
+		{"COOP", scanner.COOPChecker{}, http.Header{"Cross-Origin-Opener-Policy": {"same-origin", ""}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -222,6 +224,33 @@ func TestReferrerPolicyWeakFallbackList(t *testing.T) {
 			}
 			if findings[0].Message == "" {
 				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestCOOPWeakValues(t *testing.T) {
+	tests := []string{"unsafe-none", "UNSAFE-NONE", "garbage"}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.COOPChecker{}.Check(http.Header{"Cross-Origin-Opener-Policy": {value}})
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestCOOPAcceptsCaseInsensitiveValidValues(t *testing.T) {
+	tests := []string{"same-origin", "SAME-ORIGIN", "same-origin-allow-popups", "SAME-ORIGIN-ALLOW-POPUPS"}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.COOPChecker{}.Check(http.Header{"Cross-Origin-Opener-Policy": {value}})
+			if findings[0].Status != scanner.StatusPass {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
 			}
 		})
 	}

--- a/internal/scanner/runall_test.go
+++ b/internal/scanner/runall_test.go
@@ -22,11 +22,12 @@ func TestRunAllFansOutAcrossDefaultCheckers(t *testing.T) {
 	// itself a finding) and the expected count/map below is unaffected by
 	// its inclusion in DefaultCheckers().
 	want := map[string]scanner.Status{
-		"Strict-Transport-Security": scanner.StatusMissing,
-		"X-Content-Type-Options":    scanner.StatusMissing,
-		"X-Frame-Options":           scanner.StatusMissing,
-		"Content-Security-Policy":   scanner.StatusPass,
-		"Referrer-Policy":           scanner.StatusMissing,
+		"Strict-Transport-Security":  scanner.StatusMissing,
+		"X-Content-Type-Options":     scanner.StatusMissing,
+		"X-Frame-Options":            scanner.StatusMissing,
+		"Content-Security-Policy":    scanner.StatusPass,
+		"Referrer-Policy":            scanner.StatusMissing,
+		"Cross-Origin-Opener-Policy": scanner.StatusMissing,
 	}
 	if len(findings) != len(want) {
 		t.Fatalf("RunAll() returned %d findings, want %d", len(findings), len(want))

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -12,11 +12,12 @@ import (
 )
 
 var allSecurityHeaders = map[string]string{
-	"Strict-Transport-Security": "max-age=63072000",
-	"X-Content-Type-Options":    "nosniff",
-	"X-Frame-Options":           "DENY",
-	"Content-Security-Policy":   "default-src 'self'",
-	"Referrer-Policy":           "no-referrer",
+	"Strict-Transport-Security":  "max-age=63072000",
+	"X-Content-Type-Options":     "nosniff",
+	"X-Frame-Options":            "DENY",
+	"Content-Security-Policy":    "default-src 'self'",
+	"Referrer-Policy":            "no-referrer",
+	"Cross-Origin-Opener-Policy": "same-origin",
 }
 
 func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
@@ -25,8 +26,8 @@ func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
 	t.Cleanup(srv.Close)
 
 	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), []string{srv.URL}, 1)
-	if len(findings) != 5 {
-		t.Fatalf("Scan() returned %d findings, want 5", len(findings))
+	if len(findings) != 6 {
+		t.Fatalf("Scan() returned %d findings, want 6", len(findings))
 	}
 	for _, f := range findings {
 		if f.URL != srv.URL {
@@ -79,8 +80,8 @@ func TestScanCoversMultipleURLs(t *testing.T) {
 	t.Cleanup(srvB.Close)
 
 	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), []string{srvA.URL, srvB.URL}, 2)
-	if len(findings) != 10 {
-		t.Fatalf("Scan() returned %d findings, want 10 (5 per URL)", len(findings))
+	if len(findings) != 12 {
+		t.Fatalf("Scan() returned %d findings, want 12 (6 per URL)", len(findings))
 	}
 }
 
@@ -145,8 +146,8 @@ func TestScanReportsAllTargetsDespiteFailures(t *testing.T) {
 	if got := len(byURL[deadURL]); got != 1 {
 		t.Errorf("dead target has %d findings, want 1 error finding", got)
 	}
-	if got := len(byURL[healthy.URL]); got != 5 {
-		t.Errorf("healthy target has %d findings, want 5", got)
+	if got := len(byURL[healthy.URL]); got != 6 {
+		t.Errorf("healthy target has %d findings, want 6", got)
 	}
 }
 
@@ -165,8 +166,8 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), urls, targets)
 
 	assertAllStatus(t, findings, scanner.StatusMissing)
-	if len(findings) != targets*5 {
-		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*5)
+	if len(findings) != targets*6 {
+		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*6)
 	}
 }
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -10,4 +10,5 @@ header_pages:
   - checks/x-frame-options.md
   - checks/content-security-policy.md
   - checks/referrer-policy.md
+  - checks/cross-origin-opener-policy.md
   - checks/set-cookie.md

--- a/site/checks/cross-origin-opener-policy.md
+++ b/site/checks/cross-origin-opener-policy.md
@@ -1,0 +1,35 @@
+---
+layout: page
+title: Cross-Origin-Opener-Policy
+permalink: /checks/cross-origin-opener-policy
+---
+
+**Severity:** medium
+
+## What it does
+
+Controls whether the page shares a browsing context group with cross-origin popups and windows that open it. Without isolation, a cross-origin window that opens your page can hold a reference to it (and vice versa), which cross-origin attacks like Spectre can exploit to read data across the boundary.
+
+## Expected value
+
+```
+Cross-Origin-Opener-Policy: same-origin
+```
+
+or
+
+```
+Cross-Origin-Opener-Policy: same-origin-allow-popups
+```
+
+- `same-origin` — full isolation; the page never shares a browsing context group with a cross-origin document. Safest option.
+- `same-origin-allow-popups` — partial isolation; popups the page opens keep their own context group, but the opener relationship with the page itself is still isolated from other origins.
+- `unsafe-none` — the default when the header is absent. No isolation at all.
+
+## What mamori checks
+
+Presence of the header, and that its value provides some isolation. A missing header is reported as a medium-severity finding. A present header set to `unsafe-none` or any unrecognized value is reported as `WEAK`, since it leaves the page unisolated — `same-origin` and `same-origin-allow-popups` are both accepted, since either is a real improvement over no isolation.
+
+## Further reading
+
+- [MDN: Cross-Origin-Opener-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy)

--- a/site/index.md
+++ b/site/index.md
@@ -14,4 +14,5 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `X-Frame-Options` | medium | [docs](checks/x-frame-options) |
 | `Content-Security-Policy` | high | [docs](checks/content-security-policy) |
 | `Referrer-Policy` | low | [docs](checks/referrer-policy) |
+| `Cross-Origin-Opener-Policy` | medium | [docs](checks/cross-origin-opener-policy) |
 | `Set-Cookie` | high / medium | [docs](checks/set-cookie) |


### PR DESCRIPTION
## What/why

Adds `COOPChecker` to flag a missing or weak `Cross-Origin-Opener-Policy` header, following the existing checker pattern in `internal/scanner/checkers.go`.

COOP has three valid values: `unsafe-none` (default, no isolation), `same-origin-allow-popups` (partial isolation), and `same-origin` (full isolation). Per the issue's Agent Brief, `StatusWeak` is reported only for `unsafe-none` or unrecognized values — the checker doesn't require the strictest option, matching the existing `FrameOptionsChecker`/`referrerPolicyWeakness` approach. Severity is medium, and findings link to MDN's Cross-Origin-Opener-Policy page.

Also updates:
- `DefaultCheckers()` and all existing tests/fixtures that hardcode the checker count (5→6 findings per target) or a "passes every check" header set, so the new checker's `missing` finding doesn't silently break them.
- `site/index.md`, `site/_config.yml`, and a new `site/checks/cross-origin-opener-policy.md` page, mirroring how prior checkers were documented.
- `README.md`'s header list and example output, which were otherwise left stale by the new checker.

## Test evidence

```
$ go build ./... && go vet ./... && go test ./...
ok  	github.com/PhyberApex/mamori/cmd/mamori
ok  	github.com/PhyberApex/mamori/internal/config
ok  	github.com/PhyberApex/mamori/internal/scanner
```

New tests: `TestCOOPWeakValues`, `TestCOOPAcceptsCaseInsensitiveValidValues`, plus `COOPChecker` added to the shared identity/blank-duplicate-occurrence table tests in `checkers_test.go`.

Ran `/mattpocock-skills:code-review` (8 finder agents) against the merge-base with `origin/main` and fixed the actionable findings: aligned `coopWeakness`'s case-insensitive matching with the file's `strings.EqualFold` convention, detached its doc comment from naming sibling functions, and brought `README.md` up to date with the new checker. Findings suggesting `restrict-properties` should be accepted were not applied — the Agent Brief explicitly enumerates three valid COOP values and says to flag unrecognized values as weak.

Closes #38

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*