### PR TITLE
feat(scanner): add Cross-Origin-Resource-Policy checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A concurrent API security scanner built in Go
 
 `mamori` scans one or more HTTP(S) endpoints for missing or misconfigured
 security headers (HSTS, CSP, `X-Frame-Options`, `X-Content-Type-Options`,
-`Referrer-Policy`) and reports the findings, with each missing header linked
-to guidance on how to fix it.
+`Referrer-Policy`, `Cross-Origin-Resource-Policy`) and reports the findings,
+with each missing header linked to guidance on how to fix it.
 
 ## Install
 
@@ -54,6 +54,7 @@ https://example.com
   [MISSING] X-Frame-Options (medium) → https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html
   [MISSING] Content-Security-Policy (high) → https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
   [MISSING] Referrer-Policy (low) → https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#referrer-policy
+  [MISSING] Cross-Origin-Resource-Policy (medium) → https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy
 ```
 
 Full reference for every check mamori performs is available at

--- a/cmd/mamori/main_test.go
+++ b/cmd/mamori/main_test.go
@@ -12,11 +12,12 @@ import (
 // server built from this map alone never trips -fail-on at any severity.
 func strongHeaders() map[string]string {
 	return map[string]string{
-		"Strict-Transport-Security": "max-age=63072000; includeSubDomains",
-		"X-Content-Type-Options":    "nosniff",
-		"X-Frame-Options":           "DENY",
-		"Content-Security-Policy":   "default-src 'self'",
-		"Referrer-Policy":           "strict-origin-when-cross-origin",
+		"Strict-Transport-Security":    "max-age=63072000; includeSubDomains",
+		"X-Content-Type-Options":       "nosniff",
+		"X-Frame-Options":              "DENY",
+		"Content-Security-Policy":      "default-src 'self'",
+		"Referrer-Policy":              "strict-origin-when-cross-origin",
+		"Cross-Origin-Resource-Policy": "same-origin",
 	}
 }
 

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -18,6 +18,7 @@ func DefaultCheckers() []Checker {
 		FrameOptionsChecker{},
 		CSPChecker{},
 		ReferrerPolicyChecker{},
+		CORPChecker{},
 		CookieChecker{},
 	}
 }
@@ -173,6 +174,33 @@ func effectiveReferrerPolicy(value string) string {
 		}
 	}
 	return effective
+}
+
+type CORPChecker struct{}
+
+func (CORPChecker) Check(headers http.Header) []Finding {
+	return checkValue(
+		headers,
+		"Cross-Origin-Resource-Policy",
+		SeverityMedium,
+		"https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy",
+		corpWeakness,
+	)
+}
+
+// corpWeakness flags cross-origin, which explicitly opts back out of the
+// protection this header exists to provide, and any value the spec doesn't
+// define, which browsers don't recognize and so also provides no
+// protection — same treatment as a missing header in both cases.
+func corpWeakness(value string) (weak bool, message string) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "same-site", "same-origin":
+		return false, ""
+	case "cross-origin":
+		return true, "cross-origin opts out of cross-origin resource protection"
+	default:
+		return true, fmt.Sprintf("%q is not same-site, same-origin, or cross-origin and provides no protection", value)
+	}
 }
 
 const cookieReference = "https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html"

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -20,6 +20,7 @@ func TestCheckersIdentity(t *testing.T) {
 		{scanner.FrameOptionsChecker{}, "X-Frame-Options", scanner.SeverityMedium, "DENY"},
 		{scanner.CSPChecker{}, "Content-Security-Policy", scanner.SeverityHigh, "default-src 'self'"},
 		{scanner.ReferrerPolicyChecker{}, "Referrer-Policy", scanner.SeverityLow, "strict-origin-when-cross-origin"},
+		{scanner.CORPChecker{}, "Cross-Origin-Resource-Policy", scanner.SeverityMedium, "same-origin"},
 	}
 
 	for _, tt := range tests {
@@ -127,6 +128,7 @@ func TestCheckValueIgnoresBlankDuplicateOccurrence(t *testing.T) {
 		{"ContentTypeOptions", scanner.ContentTypeOptionsChecker{}, http.Header{"X-Content-Type-Options": {"nosniff", ""}}},
 		{"FrameOptions", scanner.FrameOptionsChecker{}, http.Header{"X-Frame-Options": {"DENY", ""}}},
 		{"ReferrerPolicy", scanner.ReferrerPolicyChecker{}, http.Header{"Referrer-Policy": {"strict-origin-when-cross-origin", ""}}},
+		{"CORP", scanner.CORPChecker{}, http.Header{"Cross-Origin-Resource-Policy": {"same-origin", ""}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -222,6 +224,39 @@ func TestReferrerPolicyWeakFallbackList(t *testing.T) {
 			}
 			if findings[0].Message == "" {
 				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestCORPWeakValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"cross-origin opts out", "cross-origin"},
+		{"unrecognized value", "garbage"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.CORPChecker{}.Check(http.Header{"Cross-Origin-Resource-Policy": {tt.value}})
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestCORPAcceptsCaseInsensitiveValidValues(t *testing.T) {
+	tests := []string{"same-site", "SAME-SITE", "same-origin", "SAME-ORIGIN"}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.CORPChecker{}.Check(http.Header{"Cross-Origin-Resource-Policy": {value}})
+			if findings[0].Status != scanner.StatusPass {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
 			}
 		})
 	}

--- a/internal/scanner/runall_test.go
+++ b/internal/scanner/runall_test.go
@@ -22,11 +22,12 @@ func TestRunAllFansOutAcrossDefaultCheckers(t *testing.T) {
 	// itself a finding) and the expected count/map below is unaffected by
 	// its inclusion in DefaultCheckers().
 	want := map[string]scanner.Status{
-		"Strict-Transport-Security": scanner.StatusMissing,
-		"X-Content-Type-Options":    scanner.StatusMissing,
-		"X-Frame-Options":           scanner.StatusMissing,
-		"Content-Security-Policy":   scanner.StatusPass,
-		"Referrer-Policy":           scanner.StatusMissing,
+		"Strict-Transport-Security":    scanner.StatusMissing,
+		"X-Content-Type-Options":       scanner.StatusMissing,
+		"X-Frame-Options":              scanner.StatusMissing,
+		"Content-Security-Policy":      scanner.StatusPass,
+		"Referrer-Policy":              scanner.StatusMissing,
+		"Cross-Origin-Resource-Policy": scanner.StatusMissing,
 	}
 	if len(findings) != len(want) {
 		t.Fatalf("RunAll() returned %d findings, want %d", len(findings), len(want))

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -12,11 +12,12 @@ import (
 )
 
 var allSecurityHeaders = map[string]string{
-	"Strict-Transport-Security": "max-age=63072000",
-	"X-Content-Type-Options":    "nosniff",
-	"X-Frame-Options":           "DENY",
-	"Content-Security-Policy":   "default-src 'self'",
-	"Referrer-Policy":           "no-referrer",
+	"Strict-Transport-Security":    "max-age=63072000",
+	"X-Content-Type-Options":       "nosniff",
+	"X-Frame-Options":              "DENY",
+	"Content-Security-Policy":      "default-src 'self'",
+	"Referrer-Policy":              "no-referrer",
+	"Cross-Origin-Resource-Policy": "same-origin",
 }
 
 func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
@@ -25,8 +26,8 @@ func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
 	t.Cleanup(srv.Close)
 
 	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), []string{srv.URL}, 1)
-	if len(findings) != 5 {
-		t.Fatalf("Scan() returned %d findings, want 5", len(findings))
+	if len(findings) != 6 {
+		t.Fatalf("Scan() returned %d findings, want 6", len(findings))
 	}
 	for _, f := range findings {
 		if f.URL != srv.URL {
@@ -79,8 +80,8 @@ func TestScanCoversMultipleURLs(t *testing.T) {
 	t.Cleanup(srvB.Close)
 
 	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), []string{srvA.URL, srvB.URL}, 2)
-	if len(findings) != 10 {
-		t.Fatalf("Scan() returned %d findings, want 10 (5 per URL)", len(findings))
+	if len(findings) != 12 {
+		t.Fatalf("Scan() returned %d findings, want 12 (6 per URL)", len(findings))
 	}
 }
 
@@ -145,8 +146,8 @@ func TestScanReportsAllTargetsDespiteFailures(t *testing.T) {
 	if got := len(byURL[deadURL]); got != 1 {
 		t.Errorf("dead target has %d findings, want 1 error finding", got)
 	}
-	if got := len(byURL[healthy.URL]); got != 5 {
-		t.Errorf("healthy target has %d findings, want 5", got)
+	if got := len(byURL[healthy.URL]); got != 6 {
+		t.Errorf("healthy target has %d findings, want 6", got)
 	}
 }
 
@@ -165,8 +166,8 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), urls, targets)
 
 	assertAllStatus(t, findings, scanner.StatusMissing)
-	if len(findings) != targets*5 {
-		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*5)
+	if len(findings) != targets*6 {
+		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*6)
 	}
 }
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -10,4 +10,5 @@ header_pages:
   - checks/x-frame-options.md
   - checks/content-security-policy.md
   - checks/referrer-policy.md
+  - checks/cross-origin-resource-policy.md
   - checks/set-cookie.md

--- a/site/checks/cross-origin-resource-policy.md
+++ b/site/checks/cross-origin-resource-policy.md
@@ -1,0 +1,35 @@
+---
+layout: page
+title: Cross-Origin-Resource-Policy
+permalink: /checks/cross-origin-resource-policy
+---
+
+**Severity:** medium
+
+## What it does
+
+Controls which origins can load this resource (images, scripts, etc.) via no-cors cross-origin requests. Without it, other sites can embed the resource and use side channels (like Spectre) to read data that should be off-limits to them.
+
+## Expected value
+
+```
+Cross-Origin-Resource-Policy: same-origin
+```
+
+or
+
+```
+Cross-Origin-Resource-Policy: same-site
+```
+
+- `same-origin` — only requests from the exact same origin can load the resource. Safest option.
+- `same-site` — requests from the same registrable domain (including other subdomains/schemes/ports) can load the resource.
+
+## What mamori checks
+
+Presence of the header, and that its value is one of the two protective values the spec defines. A missing header is reported as a medium-severity finding. A present header set to `cross-origin` — which explicitly opts back out of the protection — or any other unrecognized value is reported as `WEAK`, since neither restricts which origins can load the resource.
+
+## Further reading
+
+- [MDN: Cross-Origin-Resource-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy)
+- [OWASP: Secure Headers](https://owasp.org/www-project-secure-headers/)

--- a/site/index.md
+++ b/site/index.md
@@ -14,4 +14,5 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `X-Frame-Options` | medium | [docs](checks/x-frame-options) |
 | `Content-Security-Policy` | high | [docs](checks/content-security-policy) |
 | `Referrer-Policy` | low | [docs](checks/referrer-policy) |
+| `Cross-Origin-Resource-Policy` | medium | [docs](checks/cross-origin-resource-policy) |
 | `Set-Cookie` | high / medium | [docs](checks/set-cookie) |


### PR DESCRIPTION
## Summary

Adds a `CORPChecker` that flags a missing or weak `Cross-Origin-Resource-Policy` header, following the existing `checkValue`/weakness-function pattern used by the other checkers in `internal/scanner/checkers.go`.

- `same-site` / `same-origin` (case-insensitive) → pass.
- `cross-origin` (explicitly opts out of protection) → `StatusWeak`, medium severity.
- Any other/unrecognized value → `StatusWeak`, medium severity (same treatment as sibling checkers like `X-Frame-Options` give an unrecognized value).
- Missing header → `StatusMissing`, medium severity.
- Reference: [MDN Cross-Origin-Resource-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy), per the issue's Agent Brief.

Also registers the checker in `DefaultCheckers()`, updates the README's header list/example output, and adds a `site/checks/cross-origin-resource-policy.md` reference page (linked from `site/index.md` and `site/_config.yml`'s nav) to keep the docs site pattern the other checks follow.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./... -count=1` — all packages pass, including new `TestCORPWeakValues` / `TestCORPAcceptsCaseInsensitiveValidValues` and updated identity/RunAll/Scan finding-count tests
- [x] Ran `/mattpocock-skills:code-review` (Standards + Spec axes) against `origin/main`; fixed the one finding it surfaced (new site page wasn't registered in `site/_config.yml`'s `header_pages`)

Closes #39

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*