### PR TITLE
feat(scanner): flag weak CSP values beyond mere presence

### DIFF
--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -113,12 +113,52 @@ func frameOptionsWeakness(value string) (weak bool, message string) {
 type CSPChecker struct{}
 
 func (CSPChecker) Check(headers http.Header) []Finding {
-	return checkPresence(
+	return checkValue(
 		headers,
 		"Content-Security-Policy",
 		SeverityHigh,
 		"https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html",
+		cspWeakness,
 	)
+}
+
+// cspWeakness flags a CSP value that's present but provides little real
+// protection: 'unsafe-inline'/'unsafe-eval' in any directive re-enable the
+// exact inline-script and string-to-code execution CSP exists to block, a
+// bare "*" source allows loading that content from any origin, and a policy
+// with neither object-src nor default-src leaves plugin content (e.g.
+// Flash/PDF embeds) completely unrestricted — object-src falls back to
+// default-src per spec, so only missing both is a gap.
+func cspWeakness(value string) (weak bool, message string) {
+	hasObjectSrc := false
+	hasDefaultSrc := false
+	for _, directive := range strings.Split(value, ";") {
+		fields := strings.Fields(directive)
+		if len(fields) == 0 {
+			continue
+		}
+		name := strings.ToLower(fields[0])
+		switch name {
+		case "object-src":
+			hasObjectSrc = true
+		case "default-src":
+			hasDefaultSrc = true
+		}
+		for _, source := range fields[1:] {
+			switch strings.ToLower(source) {
+			case "'unsafe-inline'":
+				return true, fmt.Sprintf("%s allows 'unsafe-inline', which permits inline scripts/styles and defeats CSP's XSS protection", name)
+			case "'unsafe-eval'":
+				return true, fmt.Sprintf("%s allows 'unsafe-eval', which permits string-to-code execution (eval, Function, etc.)", name)
+			case "*":
+				return true, fmt.Sprintf("%s allows * as a source, permitting content from any origin", name)
+			}
+		}
+	}
+	if !hasObjectSrc && !hasDefaultSrc {
+		return true, "missing both object-src and default-src, leaving plugin/legacy content unrestricted"
+	}
+	return false, ""
 }
 
 type ReferrerPolicyChecker struct{}

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -126,6 +126,7 @@ func TestCheckValueIgnoresBlankDuplicateOccurrence(t *testing.T) {
 		{"HSTS", scanner.HSTSChecker{}, http.Header{"Strict-Transport-Security": {"max-age=63072000", ""}}},
 		{"ContentTypeOptions", scanner.ContentTypeOptionsChecker{}, http.Header{"X-Content-Type-Options": {"nosniff", ""}}},
 		{"FrameOptions", scanner.FrameOptionsChecker{}, http.Header{"X-Frame-Options": {"DENY", ""}}},
+		{"CSP", scanner.CSPChecker{}, http.Header{"Content-Security-Policy": {"default-src 'self'", ""}}},
 		{"ReferrerPolicy", scanner.ReferrerPolicyChecker{}, http.Header{"Referrer-Policy": {"strict-origin-when-cross-origin", ""}}},
 	}
 	for _, tt := range tests {
@@ -222,6 +223,46 @@ func TestReferrerPolicyWeakFallbackList(t *testing.T) {
 			}
 			if findings[0].Message == "" {
 				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestCSPWeakValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"unsafe-inline in script-src", "default-src 'self'; script-src 'unsafe-inline'; object-src 'none'"},
+		{"unsafe-eval in script-src", "default-src 'self'; script-src 'unsafe-eval'; object-src 'none'"},
+		{"unsafe-inline case-insensitive", "default-src 'self'; script-src 'UNSAFE-INLINE'; object-src 'none'"},
+		{"bare wildcard source", "default-src 'self'; img-src *; object-src 'none'"},
+		{"missing object-src and default-src", "script-src 'self'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.CSPChecker{}.Check(http.Header{"Content-Security-Policy": {tt.value}})
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestCSPAcceptsStrongValues(t *testing.T) {
+	tests := []string{
+		"default-src 'self'",
+		"object-src 'none'; script-src 'self'",
+		"default-src 'self'; img-src https://*.example.com",
+	}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.CSPChecker{}.Check(http.Header{"Content-Security-Policy": {value}})
+			if findings[0].Status != scanner.StatusPass {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
 			}
 		})
 	}

--- a/site/checks/content-security-policy.md
+++ b/site/checks/content-security-policy.md
@@ -22,7 +22,14 @@ This only allows resources from the same origin. Most apps need to expand this f
 
 ## What mamori checks
 
-Presence of the header. A missing header is reported as a high-severity finding. mamori does not validate the CSP value — that requires understanding your application's intent.
+Presence of the header, and whether the value is a known no-op. A missing header is reported as a high-severity finding. A present header is flagged as weak if it:
+
+- allows `'unsafe-inline'` in any directive, which permits inline scripts/styles and defeats CSP's XSS protection
+- allows `'unsafe-eval'` in any directive, which permits string-to-code execution (`eval`, `Function`, etc.)
+- allows a bare `*` source, which permits loading that content from any origin
+- lacks both `object-src` and `default-src`, leaving plugin/legacy content unrestricted (`object-src` falls back to `default-src` per spec, so only missing both is a gap)
+
+Beyond these checks, CSP values are highly application-specific — mamori does not validate the full policy against your application's intent.
 
 ## Further reading
 


### PR DESCRIPTION
## What

Extends `CSPChecker` to inspect the `Content-Security-Policy` value, not just its presence, following the same `checkValue`/weakness-validator pattern already used by HSTS and X-Frame-Options.

A present policy is now flagged `StatusWeak` (high severity, same as before) when it:
- allows `'unsafe-inline'` in any directive
- allows `'unsafe-eval'` in any directive
- allows a bare `*` source
- lacks both `object-src` and `default-src` (object-src falls back to default-src per spec, so only missing both is a gap)

## Why

CSP is one of the strongest defenses against XSS, but a header that's merely *present* can still be a functional no-op (e.g. `default-src 'self'; script-src 'unsafe-inline'`). Closes #42.

## Test evidence

```
$ go build ./... && go vet ./... && go test ./...
ok  	github.com/PhyberApex/mamori/cmd/mamori
ok  	github.com/PhyberApex/mamori/internal/config
ok  	github.com/PhyberApex/mamori/internal/scanner
```

New tests: `TestCSPWeakValues`, `TestCSPAcceptsStrongValues`, plus CSP added to the existing blank-duplicate-occurrence table test.

Ran `/mattpocock-skills:code-review` against the merge-base with `origin/main` (Standards + Spec axes, parallel sub-agents). No hard violations; the one implementation-risk finding (per-occurrence flagging for the object-src/default-src check could misjudge a CSP deliberately split across multiple header instances) is a documented, repo-wide tradeoff shared by every checker using `checkValue`, and the issue's Agent Brief explicitly asked to reuse that pattern — so left as-is rather than adding CSP-specific cross-occurrence logic.

Closes #42

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*