### PR TITLE
feat(scanner): add server banner disclosure checker

### DIFF
--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -248,17 +248,24 @@ type BannerDisclosureChecker struct{}
 func (BannerDisclosureChecker) Check(headers http.Header) []Finding {
 	var findings []Finding
 	for _, name := range bannerHeaderNames {
-		value := strings.TrimSpace(headers.Get(name))
-		if value == "" {
-			continue
+		// A misconfigured proxy or CDN can append a blank duplicate of the
+		// header instead of leaving the origin's alone; headers.Get would
+		// only ever see whichever occurrence happens to be first and could
+		// miss a later, disclosing one. Report the first non-blank value.
+		for _, raw := range headers.Values(name) {
+			value := strings.TrimSpace(raw)
+			if value == "" {
+				continue
+			}
+			findings = append(findings, Finding{
+				Header:    name,
+				Status:    StatusWeak,
+				Severity:  SeverityLow,
+				Reference: bannerDisclosureReference,
+				Message:   fmt.Sprintf("%q reveals backend software/version info useful for fingerprinting the server", value),
+			})
+			break
 		}
-		findings = append(findings, Finding{
-			Header:    name,
-			Status:    StatusWeak,
-			Severity:  SeverityLow,
-			Reference: bannerDisclosureReference,
-			Message:   fmt.Sprintf("%q reveals backend software/version info useful for fingerprinting the server", value),
-		})
 	}
 	return findings
 }

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -19,6 +19,7 @@ func DefaultCheckers() []Checker {
 		CSPChecker{},
 		ReferrerPolicyChecker{},
 		CookieChecker{},
+		BannerDisclosureChecker{},
 	}
 }
 
@@ -230,6 +231,45 @@ func cookieFindings(cookie *http.Cookie) []Finding {
 			Severity:  attr.severity,
 			Reference: cookieReference,
 			Message:   fmt.Sprintf("cookie %q %s", cookie.Name, attr.message),
+		})
+	}
+	return findings
+}
+
+const bannerDisclosureReference = "https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html"
+
+// bannerHeaders lists the headers BannerDisclosureChecker judges. Unlike the
+// other checkers, presence rather than absence is the finding: both headers
+// exist only to advertise backend software/version info, which is useful to
+// an attacker fingerprinting the stack and useful to nobody else.
+var bannerHeaders = []struct {
+	name      string
+	reference string
+}{
+	{"Server", bannerDisclosureReference + "#server"},
+	{"X-Powered-By", bannerDisclosureReference + "#x-powered-by"},
+}
+
+// BannerDisclosureChecker flags the Server and X-Powered-By headers whenever
+// they carry a value. There's no StatusPass/StatusMissing case here: absence
+// is the desired state and isn't itself worth reporting, so a response with
+// neither header produces no findings at all, mirroring how CookieChecker
+// treats a response with no cookies as having nothing to protect.
+type BannerDisclosureChecker struct{}
+
+func (BannerDisclosureChecker) Check(headers http.Header) []Finding {
+	var findings []Finding
+	for _, h := range bannerHeaders {
+		value := strings.TrimSpace(headers.Get(h.name))
+		if value == "" {
+			continue
+		}
+		findings = append(findings, Finding{
+			Header:    h.name,
+			Status:    StatusWeak,
+			Severity:  SeverityLow,
+			Reference: h.reference,
+			Message:   fmt.Sprintf("%q reveals backend software/version info useful for fingerprinting the server", value),
 		})
 	}
 	return findings

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -238,18 +238,6 @@ func cookieFindings(cookie *http.Cookie) []Finding {
 
 const bannerDisclosureReference = "https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html"
 
-// bannerHeaders lists the headers BannerDisclosureChecker judges. Unlike the
-// other checkers, presence rather than absence is the finding: both headers
-// exist only to advertise backend software/version info, which is useful to
-// an attacker fingerprinting the stack and useful to nobody else.
-var bannerHeaders = []struct {
-	name      string
-	reference string
-}{
-	{"Server", bannerDisclosureReference + "#server"},
-	{"X-Powered-By", bannerDisclosureReference + "#x-powered-by"},
-}
-
 // BannerDisclosureChecker flags the Server and X-Powered-By headers whenever
 // they carry a value. There's no StatusPass/StatusMissing case here: absence
 // is the desired state and isn't itself worth reporting, so a response with
@@ -259,21 +247,27 @@ type BannerDisclosureChecker struct{}
 
 func (BannerDisclosureChecker) Check(headers http.Header) []Finding {
 	var findings []Finding
-	for _, h := range bannerHeaders {
-		value := strings.TrimSpace(headers.Get(h.name))
+	for _, name := range bannerHeaderNames {
+		value := strings.TrimSpace(headers.Get(name))
 		if value == "" {
 			continue
 		}
 		findings = append(findings, Finding{
-			Header:    h.name,
+			Header:    name,
 			Status:    StatusWeak,
 			Severity:  SeverityLow,
-			Reference: h.reference,
+			Reference: bannerDisclosureReference,
 			Message:   fmt.Sprintf("%q reveals backend software/version info useful for fingerprinting the server", value),
 		})
 	}
 	return findings
 }
+
+// bannerHeaderNames lists the headers BannerDisclosureChecker judges. Unlike
+// the other checkers, presence rather than absence is the finding: both
+// headers exist only to advertise backend software/version info, which is
+// useful to an attacker fingerprinting the stack and useful to nobody else.
+var bannerHeaderNames = []string{"Server", "X-Powered-By"}
 
 func checkPresence(headers http.Header, name string, severity Severity, reference string) []Finding {
 	status := StatusPass

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -365,3 +365,68 @@ func TestReferrerPolicyAcceptsFallbackListEndingStrong(t *testing.T) {
 		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
 	}
 }
+
+func TestBannerDisclosureNoHeadersProducesNoFindings(t *testing.T) {
+	findings := scanner.BannerDisclosureChecker{}.Check(http.Header{})
+	if len(findings) != 0 {
+		t.Errorf("Check() on headers with no Server/X-Powered-By returned %d findings, want 0: %+v", len(findings), findings)
+	}
+}
+
+func TestBannerDisclosureFlagsServerHeader(t *testing.T) {
+	findings := scanner.BannerDisclosureChecker{}.Check(http.Header{"Server": {"nginx/1.18.0"}})
+	if len(findings) != 1 {
+		t.Fatalf("Check() returned %d findings, want 1: %+v", len(findings), findings)
+	}
+	if findings[0].Header != "Server" {
+		t.Errorf("Header = %q, want %q", findings[0].Header, "Server")
+	}
+	if findings[0].Status != scanner.StatusWeak {
+		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+	}
+	if findings[0].Severity != scanner.SeverityLow {
+		t.Errorf("Severity = %q, want %q", findings[0].Severity, scanner.SeverityLow)
+	}
+	if findings[0].Reference == "" {
+		t.Error("Reference is empty, want a docs URL")
+	}
+	if findings[0].Message == "" {
+		t.Error("Message is empty, want an explanation")
+	}
+}
+
+func TestBannerDisclosureFlagsXPoweredByHeader(t *testing.T) {
+	findings := scanner.BannerDisclosureChecker{}.Check(http.Header{"X-Powered-By": {"PHP/8.2.0"}})
+	if len(findings) != 1 {
+		t.Fatalf("Check() returned %d findings, want 1: %+v", len(findings), findings)
+	}
+	if findings[0].Header != "X-Powered-By" {
+		t.Errorf("Header = %q, want %q", findings[0].Header, "X-Powered-By")
+	}
+	if findings[0].Status != scanner.StatusWeak {
+		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+	}
+	if findings[0].Severity != scanner.SeverityLow {
+		t.Errorf("Severity = %q, want %q", findings[0].Severity, scanner.SeverityLow)
+	}
+}
+
+func TestBannerDisclosureFlagsBothHeaders(t *testing.T) {
+	findings := scanner.BannerDisclosureChecker{}.Check(http.Header{
+		"Server":       {"nginx/1.18.0"},
+		"X-Powered-By": {"PHP/8.2.0"},
+	})
+	if len(findings) != 2 {
+		t.Fatalf("Check() returned %d findings, want 2: %+v", len(findings), findings)
+	}
+}
+
+func TestBannerDisclosureIgnoresBlankHeaderValue(t *testing.T) {
+	findings := scanner.BannerDisclosureChecker{}.Check(http.Header{
+		"Server":       {""},
+		"X-Powered-By": {""},
+	})
+	if len(findings) != 0 {
+		t.Errorf("Check() with blank header values returned %d findings, want 0: %+v", len(findings), findings)
+	}
+}

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -430,3 +430,21 @@ func TestBannerDisclosureIgnoresBlankHeaderValue(t *testing.T) {
 		t.Errorf("Check() with blank header values returned %d findings, want 0: %+v", len(findings), findings)
 	}
 }
+
+func TestBannerDisclosureFlagsValueBehindBlankDuplicateOccurrence(t *testing.T) {
+	// Some infra prepends a stray blank duplicate instead of leaving the
+	// origin's header alone. headers.Get would only see that blank first
+	// occurrence and miss the disclosing one behind it.
+	findings := scanner.BannerDisclosureChecker{}.Check(http.Header{
+		"Server": {"", "nginx/1.18.0"},
+	})
+	if len(findings) != 1 {
+		t.Fatalf("Check() returned %d findings, want 1: %+v", len(findings), findings)
+	}
+	if findings[0].Status != scanner.StatusWeak {
+		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+	}
+	if findings[0].Message == "" {
+		t.Error("Message is empty, want an explanation")
+	}
+}

--- a/site/checks/banner-disclosure.md
+++ b/site/checks/banner-disclosure.md
@@ -1,0 +1,30 @@
+---
+layout: page
+title: Banner Disclosure
+permalink: /checks/banner-disclosure
+---
+
+**Severity:** low
+
+## What it does
+
+Checks the `Server` and `X-Powered-By` headers, which exist only to advertise the backend software (and often its version) handling the request. Unlike the other checks, presence — not absence — is the problem: this information helps an attacker fingerprint the stack and target known vulnerabilities for it.
+
+## Expected value
+
+Neither header should be sent at all:
+
+```
+Server:
+X-Powered-By:
+```
+
+## What mamori checks
+
+Whether `Server` or `X-Powered-By` carries a non-empty value. A response with neither header produces no findings — absence is the desired state, so there's nothing to report. A present, non-empty value on either header is reported as a low-severity `WEAK` finding; a response can produce up to two findings, one per header.
+
+## Further reading
+
+- [MDN: Server](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server)
+- [OWASP: HTTP Headers Cheat Sheet — Server](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#server)
+- [OWASP: HTTP Headers Cheat Sheet — X-Powered-By](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-powered-by)

--- a/site/index.md
+++ b/site/index.md
@@ -15,3 +15,4 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `Content-Security-Policy` | high | [docs](checks/content-security-policy) |
 | `Referrer-Policy` | low | [docs](checks/referrer-policy) |
 | `Set-Cookie` | high / medium | [docs](checks/set-cookie) |
+| `Server` / `X-Powered-By` | low | [docs](checks/banner-disclosure) |


### PR DESCRIPTION
## What

Adds `BannerDisclosureChecker`, which flags the `Server` and `X-Powered-By` response headers whenever they carry a non-empty value. Registered in `DefaultCheckers()` alongside the existing header checks.

## Why

These two headers exist only to advertise backend software/version info, which helps an attacker fingerprint the stack. Unlike the other checks, presence (not absence) is the problem, so:

- A response with neither header produces no findings — absence is the desired state.
- A present, non-empty `Server` or `X-Powered-By` is reported as `StatusWeak` (not `StatusMissing`), severity low.
- A response can produce up to two findings, one per header.

Also adds `site/checks/banner-disclosure.md` and an `site/index.md` row, matching the docs-page-per-checker convention established when `Set-Cookie` was added (5bb8974).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` — all pass, including new `TestBannerDisclosure*` cases: no headers → 0 findings, `Server` alone, `X-Powered-By` alone, both together → 2 findings, blank header value ignored.
- [x] `gofmt -l .` — clean
- [x] Ran `/mattpocock-skills:code-review` against `origin/main` (Standards + Spec sub-agents); Spec axis found no gaps, Standards axis flagged two judgement calls (declaration order, per-item reference URLs) which were fixed to match `CookieChecker`'s existing shape.

Closes #45

---
*Opened by Kongroo, karakuri's Projects agent — Stage: implement*