### PR TITLE
feat(scanner): add mixed-content checker for https targets

### DIFF
--- a/cmd/mamori/main.go
+++ b/cmd/mamori/main.go
@@ -54,7 +54,7 @@ func run(args []string, stdin io.Reader, out io.Writer) error {
 		return err
 	}
 	client := &http.Client{Timeout: cfg.Timeout}
-	findings := scanner.Scan(context.Background(), client, scanner.DefaultCheckers(), urls, cfg.Workers)
+	findings := scanner.Scan(context.Background(), client, scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), urls, cfg.Workers)
 	if err := reporterFor(cfg.Output).Report(findings, out); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/PhyberApex/mamori
 go 1.25.2
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require golang.org/x/net v0.58.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
+golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -22,6 +23,20 @@ func DefaultCheckers() []Checker {
 		PermissionsPolicyChecker{},
 		BannerDisclosureChecker{},
 	}
+}
+
+// BodyChecker is a Checker that inspects the response body instead of its
+// headers. It's a separate interface rather than an extension of Checker
+// because it needs a fundamentally different input, and because acting on
+// it costs an extra request (see Scan) that a caller may not want to pay for
+// every target — a Checker always runs, a BodyChecker only runs when passed
+// in.
+type BodyChecker interface {
+	Check(body io.Reader) []Finding
+}
+
+func DefaultBodyCheckers() []BodyChecker {
+	return []BodyChecker{MixedContentChecker{}}
 }
 
 func RunAll(checkers []Checker, headers http.Header) []Finding {

--- a/internal/scanner/mixedcontent.go
+++ b/internal/scanner/mixedcontent.go
@@ -1,0 +1,71 @@
+package scanner
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+const mixedContentReference = "https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content"
+
+// mixedContentTags lists the elements whose src/href can load a resource of
+// their own: img/script/link/iframe/audio/video are the tags browsers apply
+// mixed-content blocking to, since each can fetch content outside the page's
+// own TLS connection.
+var mixedContentTags = map[string]bool{
+	"img":    true,
+	"script": true,
+	"link":   true,
+	"iframe": true,
+	"audio":  true,
+	"video":  true,
+}
+
+var mixedContentAttrs = map[string]bool{"src": true, "href": true}
+
+// MixedContentChecker scans an https:// response body for resource
+// references that load over plain http:// instead. Those resources bypass
+// TLS entirely, so a network attacker can tamper with or substitute them
+// even though the page itself was served securely — the padlock in the
+// address bar doesn't cover them.
+//
+// Unlike the header checkers, there's no StatusPass/StatusMissing case here:
+// a clean page has nothing to flag, so it produces no findings at all,
+// mirroring how BannerDisclosureChecker treats absence as the desired state.
+type MixedContentChecker struct{}
+
+func (MixedContentChecker) Check(body io.Reader) []Finding {
+	var findings []Finding
+	tokenizer := html.NewTokenizer(body)
+	for {
+		tt := tokenizer.Next()
+		if tt == html.ErrorToken {
+			return findings
+		}
+		if tt != html.StartTagToken && tt != html.SelfClosingTagToken {
+			continue
+		}
+		token := tokenizer.Token()
+		if !mixedContentTags[token.Data] {
+			continue
+		}
+		for _, attr := range token.Attr {
+			if !mixedContentAttrs[attr.Key] {
+				continue
+			}
+			value := strings.TrimSpace(attr.Val)
+			if !strings.HasPrefix(strings.ToLower(value), "http://") {
+				continue
+			}
+			findings = append(findings, Finding{
+				Header:    "Mixed Content",
+				Status:    StatusWeak,
+				Severity:  SeverityMedium,
+				Reference: mixedContentReference,
+				Message:   fmt.Sprintf("<%s %s=%q> loads over insecure http://, bypassing the page's TLS protection", token.Data, attr.Key, value),
+			})
+		}
+	}
+}

--- a/internal/scanner/mixedcontent.go
+++ b/internal/scanner/mixedcontent.go
@@ -8,6 +8,8 @@ import (
 	"golang.org/x/net/html"
 )
 
+const mixedContentHeader = "Mixed Content"
+
 const mixedContentReference = "https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content"
 
 // mixedContentTags lists the elements whose src/href can load a resource of
@@ -107,7 +109,7 @@ func (MixedContentChecker) Check(body io.Reader) []Finding {
 				continue
 			}
 			findings = append(findings, Finding{
-				Header:    "Mixed Content",
+				Header:    mixedContentHeader,
 				Status:    StatusWeak,
 				Severity:  SeverityMedium,
 				Reference: mixedContentReference,

--- a/internal/scanner/mixedcontent.go
+++ b/internal/scanner/mixedcontent.go
@@ -25,6 +25,43 @@ var mixedContentTags = map[string]bool{
 
 var mixedContentAttrs = map[string]bool{"src": true, "href": true}
 
+// linkFetchingRels lists the rel values that make a <link> a subresource the
+// browser actually fetches (and so applies mixed-content blocking to).
+// Most rel values — canonical, alternate, author, license, search — are pure
+// metadata the browser never dereferences, so treating every <link href>
+// as mixed content would flag the canonical tag on most real https:// pages.
+var linkFetchingRels = map[string]bool{
+	"stylesheet":                   true,
+	"icon":                         true,
+	"apple-touch-icon":             true,
+	"apple-touch-icon-precomposed": true,
+	"manifest":                     true,
+	"preload":                      true,
+	"prefetch":                     true,
+	"prerender":                    true,
+}
+
+// isFetchingLinkToken reports whether an https response would actually load
+// this token's resource: every tag besides <link> in mixedContentTags always
+// fetches its src, but a <link> only fetches href for a rel value in
+// linkFetchingRels.
+func isFetchingLinkToken(token html.Token) bool {
+	if token.Data != "link" {
+		return true
+	}
+	for _, attr := range token.Attr {
+		if attr.Key != "rel" {
+			continue
+		}
+		for _, rel := range strings.Fields(strings.ToLower(attr.Val)) {
+			if linkFetchingRels[rel] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // MixedContentChecker scans an https:// response body for resource
 // references that load over plain http:// instead. Those resources bypass
 // TLS entirely, so a network attacker can tamper with or substitute them
@@ -35,6 +72,12 @@ var mixedContentAttrs = map[string]bool{"src": true, "href": true}
 // a clean page has nothing to flag, so it produces no findings at all,
 // mirroring how BannerDisclosureChecker treats absence as the desired state.
 type MixedContentChecker struct{}
+
+var asciiWhitespaceStripper = strings.NewReplacer("\t", "", "\n", "", "\r", "")
+
+func stripASCIIWhitespace(value string) string {
+	return strings.TrimSpace(asciiWhitespaceStripper.Replace(value))
+}
 
 func (MixedContentChecker) Check(body io.Reader) []Finding {
 	var findings []Finding
@@ -48,14 +91,18 @@ func (MixedContentChecker) Check(body io.Reader) []Finding {
 			continue
 		}
 		token := tokenizer.Token()
-		if !mixedContentTags[token.Data] {
+		if !mixedContentTags[token.Data] || !isFetchingLinkToken(token) {
 			continue
 		}
 		for _, attr := range token.Attr {
 			if !mixedContentAttrs[attr.Key] {
 				continue
 			}
-			value := strings.TrimSpace(attr.Val)
+			// Browsers strip ASCII tab/newline/carriage-return from anywhere
+			// in a URL before parsing its scheme (WHATWG URL spec), not just
+			// the ends, so a value like "ht\ntp://" still resolves to plain
+			// http:// even though a plain TrimSpace wouldn't catch it.
+			value := stripASCIIWhitespace(attr.Val)
 			if !strings.HasPrefix(strings.ToLower(value), "http://") {
 				continue
 			}

--- a/internal/scanner/mixedcontent_test.go
+++ b/internal/scanner/mixedcontent_test.go
@@ -59,6 +59,32 @@ func TestMixedContentIsCaseInsensitiveToScheme(t *testing.T) {
 	}
 }
 
+func TestMixedContentIgnoresNonFetchingLinkRel(t *testing.T) {
+	body := `<html><head><link rel="canonical" href="http://insecure.example.com/page"></head></html>`
+	findings := scanner.MixedContentChecker{}.Check(strings.NewReader(body))
+	if len(findings) != 0 {
+		t.Errorf("Check() returned %d findings, want 0 (rel=canonical is never fetched by the browser): %+v", len(findings), findings)
+	}
+}
+
+func TestMixedContentFlagsFetchingLinkRel(t *testing.T) {
+	body := `<html><head><link rel="icon" href="http://insecure.example.com/favicon.ico"></head></html>`
+	findings := scanner.MixedContentChecker{}.Check(strings.NewReader(body))
+	if len(findings) != 1 {
+		t.Fatalf("Check() returned %d findings, want 1: %+v", len(findings), findings)
+	}
+}
+
+func TestMixedContentDetectsSchemeWithEmbeddedNewline(t *testing.T) {
+	// Browsers strip ASCII tab/newline/CR from anywhere in a URL before
+	// parsing it, so this still resolves to http://insecure.example.com/x.
+	body := "<html><body><img src=\"ht\ntp://insecure.example.com/x.png\"></body></html>"
+	findings := scanner.MixedContentChecker{}.Check(strings.NewReader(body))
+	if len(findings) != 1 {
+		t.Fatalf("Check() returned %d findings, want 1: %+v", len(findings), findings)
+	}
+}
+
 func TestMixedContentAllSecureProducesNoFindings(t *testing.T) {
 	body := `<html><head><link rel="stylesheet" href="https://secure.example.com/style.css"></head>
 <body><img src="https://secure.example.com/logo.png"><script src="/relative.js"></script></body></html>`

--- a/internal/scanner/mixedcontent_test.go
+++ b/internal/scanner/mixedcontent_test.go
@@ -1,0 +1,69 @@
+package scanner_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PhyberApex/mamori/internal/scanner"
+)
+
+func TestMixedContentFlagsInsecureImgSrc(t *testing.T) {
+	body := `<html><body><img src="http://insecure.example.com/logo.png"></body></html>`
+	findings := scanner.MixedContentChecker{}.Check(strings.NewReader(body))
+
+	if len(findings) != 1 {
+		t.Fatalf("Check() returned %d findings, want 1: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Status != scanner.StatusWeak {
+		t.Errorf("Status = %q, want %q", f.Status, scanner.StatusWeak)
+	}
+	if f.Severity != scanner.SeverityMedium {
+		t.Errorf("Severity = %q, want %q", f.Severity, scanner.SeverityMedium)
+	}
+	if f.Reference == "" {
+		t.Error("Reference is empty, want a docs URL")
+	}
+	if f.Message == "" {
+		t.Error("Message is empty, want an explanation")
+	}
+}
+
+func TestMixedContentFlagsEachInsecureTag(t *testing.T) {
+	body := `<html><head><link rel="stylesheet" href="http://insecure.example.com/style.css"></head>
+<body>
+<script src="http://insecure.example.com/app.js"></script>
+<iframe src="http://insecure.example.com/embed"></iframe>
+<audio src="http://insecure.example.com/a.mp3"></audio>
+<video src="http://insecure.example.com/v.mp4"></video>
+</body></html>`
+	findings := scanner.MixedContentChecker{}.Check(strings.NewReader(body))
+	if len(findings) != 5 {
+		t.Fatalf("Check() returned %d findings, want 5: %+v", len(findings), findings)
+	}
+}
+
+func TestMixedContentIgnoresProtocolRelativeURL(t *testing.T) {
+	body := `<html><body><img src="//secure.example.com/logo.png"></body></html>`
+	findings := scanner.MixedContentChecker{}.Check(strings.NewReader(body))
+	if len(findings) != 0 {
+		t.Errorf("Check() returned %d findings, want 0 (protocol-relative URLs inherit the page scheme): %+v", len(findings), findings)
+	}
+}
+
+func TestMixedContentIsCaseInsensitiveToScheme(t *testing.T) {
+	body := `<html><body><img src="HTTP://insecure.example.com/logo.png"></body></html>`
+	findings := scanner.MixedContentChecker{}.Check(strings.NewReader(body))
+	if len(findings) != 1 {
+		t.Fatalf("Check() returned %d findings, want 1: %+v", len(findings), findings)
+	}
+}
+
+func TestMixedContentAllSecureProducesNoFindings(t *testing.T) {
+	body := `<html><head><link rel="stylesheet" href="https://secure.example.com/style.css"></head>
+<body><img src="https://secure.example.com/logo.png"><script src="/relative.js"></script></body></html>`
+	findings := scanner.MixedContentChecker{}.Check(strings.NewReader(body))
+	if len(findings) != 0 {
+		t.Errorf("Check() returned %d findings, want 0: %+v", len(findings), findings)
+	}
+}

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"sync"
 )
 
@@ -46,16 +47,37 @@ func Scan(ctx context.Context, client *http.Client, checkers []Checker, urls []s
 	return findings
 }
 
-func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, url string) []Finding {
-	headers, err := fetchHeaders(ctx, client, url)
+func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, target string) []Finding {
+	headers, err := fetchHeaders(ctx, client, target)
 	if err != nil {
-		return []Finding{{URL: url, Status: StatusError, Message: err.Error()}}
+		return []Finding{{URL: target, Status: StatusError, Message: err.Error()}}
 	}
 	findings := RunAll(checkers, headers)
+	findings = append(findings, mixedContentFindings(ctx, client, target)...)
 	for i := range findings {
-		findings[i].URL = url
+		findings[i].URL = target
 	}
 	return findings
+}
+
+// mixedContentFindings scans the response body for insecure http://
+// references, but only for https:// targets — an http:// page has no TLS
+// guarantee for mixed content to undermine. The body needs a dedicated GET
+// (fetchHeaders may only have sent a HEAD), and a failure to fetch it is
+// treated as nothing to report rather than a scan error: the header checks
+// above already proved the target reachable, so a hiccup on this second
+// request shouldn't fail the whole scan.
+func mixedContentFindings(ctx context.Context, client *http.Client, target string) []Finding {
+	u, err := url.Parse(target)
+	if err != nil || u.Scheme != "https" {
+		return nil
+	}
+	body, err := fetchBody(ctx, client, target)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = body.Close() }()
+	return MixedContentChecker{}.Check(body)
 }
 
 func fetchHeaders(ctx context.Context, client *http.Client, url string) (http.Header, error) {
@@ -70,6 +92,21 @@ func fetchHeaders(ctx context.Context, client *http.Client, url string) (http.He
 		}
 	}
 	return headers, nil
+}
+
+// fetchBody issues a GET and returns the live response body for the caller
+// to read and close, unlike doRequest which drains and discards it — the
+// header checks never need the body, but mixedContentFindings does.
+func fetchBody(ctx context.Context, client *http.Client, url string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
 }
 
 func doRequest(ctx context.Context, client *http.Client, method, url string) (http.Header, int, error) {

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -95,7 +95,7 @@ func bodyFindings(ctx context.Context, client *http.Client, target string, fallb
 	if resp == nil {
 		resp, err = sendRequest(ctx, client, http.MethodGet, target)
 		if err != nil {
-			return []Finding{{Header: "Mixed Content", Status: StatusError, Message: err.Error()}}
+			return []Finding{{Header: mixedContentHeader, Status: StatusError, Message: err.Error()}}
 		}
 		defer func() { _ = resp.Body.Close() }()
 	}
@@ -109,7 +109,7 @@ func bodyFindings(ctx context.Context, client *http.Client, target string, fallb
 
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if err != nil {
-		return []Finding{{Header: "Mixed Content", Status: StatusError, Message: err.Error()}}
+		return []Finding{{Header: mixedContentHeader, Status: StatusError, Message: err.Error()}}
 	}
 	var findings []Finding
 	for _, c := range bodyCheckers {

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -1,17 +1,25 @@
 package scanner
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 )
+
+// maxBodyBytes caps how much of a response body a BodyChecker ever reads.
+// Mixed-content references live in early markup (head/early body), so a few
+// megabytes is generous — the cap exists to keep an arbitrary scan target
+// from forcing an unbounded amount of memory per request.
+const maxBodyBytes = 5 * 1024 * 1024
 
 // Scan fans the URLs out to a fixed pool of worker goroutines. A failed
 // target becomes an error finding instead of aborting the scan, so every
 // target is accounted for in the report.
-func Scan(ctx context.Context, client *http.Client, checkers []Checker, urls []string, workers int) []Finding {
+func Scan(ctx context.Context, client *http.Client, checkers []Checker, bodyCheckers []BodyChecker, urls []string, workers int) []Finding {
 	jobs := make(chan int)
 	// Each worker writes only to its own job's index, so the slice needs no
 	// mutex: distinct goroutines never touch the same element, and wg.Wait()
@@ -28,7 +36,7 @@ func Scan(ctx context.Context, client *http.Client, checkers []Checker, urls []s
 			// Ranging over a channel keeps receiving until it is closed,
 			// which is how each worker knows there is no more work.
 			for i := range jobs {
-				perTarget[i] = scanTarget(ctx, client, checkers, urls[i])
+				perTarget[i] = scanTarget(ctx, client, checkers, bodyCheckers, urls[i])
 			}
 		}()
 	}
@@ -47,74 +55,89 @@ func Scan(ctx context.Context, client *http.Client, checkers []Checker, urls []s
 	return findings
 }
 
-func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, target string) []Finding {
-	headers, err := fetchHeaders(ctx, client, target)
+func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, bodyCheckers []BodyChecker, target string) []Finding {
+	headers, fallback, err := fetchHeaders(ctx, client, target)
 	if err != nil {
 		return []Finding{{URL: target, Status: StatusError, Message: err.Error()}}
 	}
 	findings := RunAll(checkers, headers)
-	findings = append(findings, mixedContentFindings(ctx, client, target)...)
+	findings = append(findings, bodyFindings(ctx, client, target, fallback, bodyCheckers)...)
 	for i := range findings {
 		findings[i].URL = target
 	}
 	return findings
 }
 
-// mixedContentFindings scans the response body for insecure http://
-// references, but only for https:// targets — an http:// page has no TLS
-// guarantee for mixed content to undermine. The body needs a dedicated GET
-// (fetchHeaders may only have sent a HEAD), and a failure to fetch it is
-// treated as nothing to report rather than a scan error: the header checks
-// above already proved the target reachable, so a hiccup on this second
-// request shouldn't fail the whole scan.
-func mixedContentFindings(ctx context.Context, client *http.Client, target string) []Finding {
+// bodyFindings runs bodyCheckers against an https:// target's response
+// body — an http:// target has no TLS guarantee for mixed content to
+// undermine, so it's skipped entirely, and a target with no BodyCheckers
+// configured never triggers the extra request at all.
+//
+// fallback is the live response fetchHeaders already obtained by falling
+// back to GET (nil when HEAD succeeded); reusing it avoids a second GET to
+// the same target. A body-fetch failure is reported as its own StatusError
+// finding rather than silently skipped, so "zero findings" always means
+// "checked and clean," never "the check didn't run."
+func bodyFindings(ctx context.Context, client *http.Client, target string, fallback *http.Response, bodyCheckers []BodyChecker) []Finding {
+	if fallback != nil {
+		defer func() { _ = fallback.Body.Close() }()
+	}
+	if len(bodyCheckers) == 0 {
+		return nil
+	}
 	u, err := url.Parse(target)
 	if err != nil || u.Scheme != "https" {
 		return nil
 	}
-	body, err := fetchBody(ctx, client, target)
-	if err != nil {
+
+	resp := fallback
+	if resp == nil {
+		resp, err = sendRequest(ctx, client, http.MethodGet, target)
+		if err != nil {
+			return []Finding{{Header: "Mixed Content", Status: StatusError, Message: err.Error()}}
+		}
+		defer func() { _ = resp.Body.Close() }()
+	}
+	// A non-2xx response (error page, bot-challenge interstitial) or a
+	// non-HTML body (JSON API, binary download) isn't the page mamori was
+	// asked to check, so scanning it would misattribute someone else's
+	// markup as this target's mixed content.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 || !strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "html") {
 		return nil
 	}
-	defer func() { _ = body.Close() }()
-	return MixedContentChecker{}.Check(body)
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	if err != nil {
+		return []Finding{{Header: "Mixed Content", Status: StatusError, Message: err.Error()}}
+	}
+	var findings []Finding
+	for _, c := range bodyCheckers {
+		findings = append(findings, c.Check(bytes.NewReader(raw))...)
+	}
+	return findings
 }
 
-func fetchHeaders(ctx context.Context, client *http.Client, url string) (http.Header, error) {
-	headers, status, err := doRequest(ctx, client, http.MethodHead, url)
+// fetchHeaders issues a HEAD, falling back to GET if the server rejects it.
+// The returned *http.Response is non-nil only when that GET fallback ran,
+// with its body still open for bodyFindings to reuse instead of paying for
+// a second GET to the same target; the caller must close it when non-nil.
+func fetchHeaders(ctx context.Context, client *http.Client, target string) (http.Header, *http.Response, error) {
+	headers, status, err := doRequest(ctx, client, http.MethodHead, target)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	if status == http.StatusMethodNotAllowed || status == http.StatusNotImplemented {
-		headers, _, err = doRequest(ctx, client, http.MethodGet, url)
-		if err != nil {
-			return nil, err
-		}
+	if status != http.StatusMethodNotAllowed && status != http.StatusNotImplemented {
+		return headers, nil, nil
 	}
-	return headers, nil
+	resp, err := sendRequest(ctx, client, http.MethodGet, target)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp.Header, resp, nil
 }
 
-// fetchBody issues a GET and returns the live response body for the caller
-// to read and close, unlike doRequest which drains and discards it — the
-// header checks never need the body, but mixedContentFindings does.
-func fetchBody(ctx context.Context, client *http.Client, url string) (io.ReadCloser, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	return resp.Body, nil
-}
-
-func doRequest(ctx context.Context, client *http.Client, method, url string) (http.Header, int, error) {
-	req, err := http.NewRequestWithContext(ctx, method, url, http.NoBody)
-	if err != nil {
-		return nil, 0, err
-	}
-	resp, err := client.Do(req)
+func doRequest(ctx context.Context, client *http.Client, method, target string) (http.Header, int, error) {
+	resp, err := sendRequest(ctx, client, method, target)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -123,4 +146,12 @@ func doRequest(ctx context.Context, client *http.Client, method, url string) (ht
 	// Drain the body so the underlying TCP connection can be reused.
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.Header, resp.StatusCode, nil
+}
+
+func sendRequest(ctx context.Context, client *http.Client, method, target string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, target, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
 }

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -56,6 +56,7 @@ func Scan(ctx context.Context, client *http.Client, checkers []Checker, bodyChec
 }
 
 func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, bodyCheckers []BodyChecker, target string) []Finding {
+	//nolint:bodyclose // fallback's body, when non-nil, is closed by bodyFindings below, which takes ownership of it
 	headers, fallback, err := fetchHeaders(ctx, client, target)
 	if err != nil {
 		return []Finding{{URL: target, Status: StatusError, Message: err.Error()}}

--- a/internal/scanner/scan_mixedcontent_test.go
+++ b/internal/scanner/scan_mixedcontent_test.go
@@ -1,12 +1,40 @@
 package scanner_test
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/PhyberApex/mamori/internal/scanner"
 )
+
+// failGETTransport lets HEAD through to a real server but fails every GET,
+// simulating a body fetch that breaks after the header fetch already
+// succeeded (e.g. a transient failure or a WAF blocking the second request).
+type failGETTransport struct {
+	http.RoundTripper
+}
+
+func (t failGETTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method == http.MethodGet {
+		return nil, errors.New("simulated GET failure")
+	}
+	return t.RoundTripper.RoundTrip(req)
+}
+
+func mixedContentOnly(findings []scanner.Finding) []scanner.Finding {
+	var out []scanner.Finding
+	for _, f := range findings {
+		if f.Header == "Mixed Content" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
 
 func TestScanFlagsMixedContentOnHTTPSTarget(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -15,19 +43,35 @@ func TestScanFlagsMixedContentOnHTTPSTarget(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), []string{srv.URL}, 1)
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), []string{srv.URL}, 1)
 
-	var mixedContent []scanner.Finding
-	for _, f := range findings {
-		if f.Header == "Mixed Content" {
-			mixedContent = append(mixedContent, f)
-		}
-	}
+	mixedContent := mixedContentOnly(findings)
 	if len(mixedContent) != 1 {
 		t.Fatalf("Scan() returned %d Mixed Content findings, want 1: %+v", len(mixedContent), findings)
 	}
 	if mixedContent[0].URL != srv.URL {
 		t.Errorf("URL = %q, want %q", mixedContent[0].URL, srv.URL)
+	}
+}
+
+func TestScanReportsErrorWhenMixedContentBodyFetchFails(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(srv.Close)
+
+	client := srv.Client()
+	client.Transport = failGETTransport{RoundTripper: client.Transport}
+
+	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), []string{srv.URL}, 1)
+
+	mixedContent := mixedContentOnly(findings)
+	if len(mixedContent) != 1 {
+		t.Fatalf("Scan() returned %d Mixed Content findings, want 1: %+v", len(mixedContent), findings)
+	}
+	if mixedContent[0].Status != scanner.StatusError {
+		t.Errorf("Status = %q, want %q", mixedContent[0].Status, scanner.StatusError)
+	}
+	if mixedContent[0].Message == "" {
+		t.Error("Message is empty, want the failure message")
 	}
 }
 
@@ -38,11 +82,103 @@ func TestScanSkipsMixedContentCheckOnHTTPTarget(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), []string{srv.URL}, 1)
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), []string{srv.URL}, 1)
 
-	for _, f := range findings {
-		if f.Header == "Mixed Content" {
-			t.Errorf("got Mixed Content finding on an http:// target, want none: %+v", f)
+	if got := mixedContentOnly(findings); len(got) != 0 {
+		t.Errorf("got %d Mixed Content findings on an http:// target, want 0: %+v", len(got), got)
+	}
+}
+
+func TestScanSkipsMixedContentCheckWithoutBodyCheckers(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><img src="http://insecure.example.com/logo.png"></body></html>`))
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, []string{srv.URL}, 1)
+
+	if got := mixedContentOnly(findings); len(got) != 0 {
+		t.Errorf("got %d Mixed Content findings with no BodyCheckers configured, want 0: %+v", len(got), got)
+	}
+}
+
+func TestScanSkipsMixedContentOnNonHTMLContentType(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"src":"http://insecure.example.com/logo.png"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), []string{srv.URL}, 1)
+
+	if got := mixedContentOnly(findings); len(got) != 0 {
+		t.Errorf("got %d Mixed Content findings on a non-HTML response, want 0: %+v", len(got), got)
+	}
+}
+
+func TestScanSkipsMixedContentOnErrorStatus(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`<html><body><img src="http://insecure.example.com/logo.png"></body></html>`))
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), []string{srv.URL}, 1)
+
+	if got := mixedContentOnly(findings); len(got) != 0 {
+		t.Errorf("got %d Mixed Content findings on a 503 response, want 0 (not the real page): %+v", len(got), got)
+	}
+}
+
+func TestScanReusesFallbackGETBodyWhenHEADRejected(t *testing.T) {
+	var gets atomic.Int64
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
 		}
+		gets.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><img src="http://insecure.example.com/logo.png"></body></html>`))
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), []string{srv.URL}, 1)
+
+	if got := mixedContentOnly(findings); len(got) != 1 {
+		t.Fatalf("Scan() returned %d Mixed Content findings, want 1: %+v", len(got), findings)
+	}
+	if n := gets.Load(); n != 1 {
+		t.Errorf("server received %d GET requests, want 1 (the HEAD-fallback body should be reused, not re-fetched)", n)
+	}
+}
+
+func TestScanCapsMixedContentBodySize(t *testing.T) {
+	// The insecure reference sits near the start of a body far larger than
+	// maxBodyBytes, so capping the read must not turn into a read error —
+	// content within the cap should still be found.
+	var body strings.Builder
+	body.WriteString(`<html><body><img src="http://insecure.example.com/logo.png">`)
+	for body.Len() < 6*1024*1024 {
+		body.WriteString("<!-- padding -->")
+	}
+	body.WriteString(`</body></html>`)
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprint(w, body.String())
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), []string{srv.URL}, 1)
+
+	got := mixedContentOnly(findings)
+	if len(got) != 1 {
+		t.Fatalf("Scan() returned %d Mixed Content findings, want 1: %+v", len(got), findings)
+	}
+	if got[0].Status == scanner.StatusError {
+		t.Errorf("a body larger than the cap should be truncated, not treated as a fetch error: %+v", got[0])
 	}
 }

--- a/internal/scanner/scan_mixedcontent_test.go
+++ b/internal/scanner/scan_mixedcontent_test.go
@@ -1,0 +1,48 @@
+package scanner_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PhyberApex/mamori/internal/scanner"
+)
+
+func TestScanFlagsMixedContentOnHTTPSTarget(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><img src="http://insecure.example.com/logo.png"></body></html>`))
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), []string{srv.URL}, 1)
+
+	var mixedContent []scanner.Finding
+	for _, f := range findings {
+		if f.Header == "Mixed Content" {
+			mixedContent = append(mixedContent, f)
+		}
+	}
+	if len(mixedContent) != 1 {
+		t.Fatalf("Scan() returned %d Mixed Content findings, want 1: %+v", len(mixedContent), findings)
+	}
+	if mixedContent[0].URL != srv.URL {
+		t.Errorf("URL = %q, want %q", mixedContent[0].URL, srv.URL)
+	}
+}
+
+func TestScanSkipsMixedContentCheckOnHTTPTarget(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><img src="http://insecure.example.com/logo.png"></body></html>`))
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), []string{srv.URL}, 1)
+
+	for _, f := range findings {
+		if f.Header == "Mixed Content" {
+			t.Errorf("got Mixed Content finding on an http:// target, want none: %+v", f)
+		}
+	}
+}

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -25,7 +25,7 @@ func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), []string{srv.URL}, 1)
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), []string{srv.URL}, 1)
 	if len(findings) != 6 {
 		t.Fatalf("Scan() returned %d findings, want 6", len(findings))
 	}
@@ -79,7 +79,7 @@ func TestScanCoversMultipleURLs(t *testing.T) {
 	srvB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	t.Cleanup(srvB.Close)
 
-	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), []string{srvA.URL, srvB.URL}, 2)
+	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), []string{srvA.URL, srvB.URL}, 2)
 	if len(findings) != 12 {
 		t.Fatalf("Scan() returned %d findings, want 12 (6 per URL)", len(findings))
 	}
@@ -90,7 +90,7 @@ func TestScanUnreachableTargetYieldsErrorFinding(t *testing.T) {
 	unreachable := srv.URL
 	srv.Close()
 
-	findings := scanner.Scan(t.Context(), http.DefaultClient, scanner.DefaultCheckers(), []string{unreachable}, 1)
+	findings := scanner.Scan(t.Context(), http.DefaultClient, scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), []string{unreachable}, 1)
 	if len(findings) != 1 {
 		t.Fatalf("Scan() returned %d findings, want 1 error finding", len(findings))
 	}
@@ -117,7 +117,7 @@ func TestScanServerTimeoutYieldsErrorFinding(t *testing.T) {
 	})
 
 	client := &http.Client{Timeout: 50 * time.Millisecond}
-	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), []string{srv.URL}, 1)
+	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), []string{srv.URL}, 1)
 	if len(findings) != 1 {
 		t.Fatalf("Scan() returned %d findings, want 1 error finding", len(findings))
 	}
@@ -137,7 +137,7 @@ func TestScanReportsAllTargetsDespiteFailures(t *testing.T) {
 	deadURL := dead.URL
 	dead.Close()
 
-	findings := scanner.Scan(t.Context(), http.DefaultClient, scanner.DefaultCheckers(), []string{deadURL, healthy.URL}, 2)
+	findings := scanner.Scan(t.Context(), http.DefaultClient, scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), []string{deadURL, healthy.URL}, 2)
 
 	byURL := map[string][]scanner.Finding{}
 	for _, f := range findings {
@@ -163,7 +163,7 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 
 	client := &http.Client{Timeout: 5 * time.Second}
 	urls := []string{srv.URL + "/a", srv.URL + "/b", srv.URL + "/c"}
-	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), urls, targets)
+	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), urls, targets)
 
 	assertAllStatus(t, findings, scanner.StatusMissing)
 	if len(findings) != targets*6 {
@@ -194,7 +194,7 @@ func TestScanBoundsConcurrencyToPoolSize(t *testing.T) {
 	for i := range urls {
 		urls[i] = srv.URL + "/" + string(rune('a'+i))
 	}
-	scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), urls, workers)
+	scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), urls, workers)
 
 	if p := peak.Load(); p > workers {
 		t.Errorf("peak concurrent requests = %d, want at most %d", p, workers)
@@ -206,7 +206,7 @@ func TestScanPreservesTargetOrder(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	urls := []string{srv.URL + "/a", srv.URL + "/b", srv.URL + "/c"}
-	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), urls, 3)
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), urls, 3)
 
 	var seen []string
 	for _, f := range findings {

--- a/site/checks/mixed-content.md
+++ b/site/checks/mixed-content.md
@@ -1,0 +1,28 @@
+---
+layout: page
+title: Mixed Content
+permalink: /checks/mixed-content
+---
+
+**Severity:** medium
+
+## What it does
+
+For `https://` targets, fetches the response body and scans it for resources — images, scripts, stylesheets, iframes, audio, and video — loaded over plain `http://` instead of `https://`. Those resources bypass TLS entirely, so a network attacker can tamper with or substitute them even though the page itself was served securely: the padlock in the address bar doesn't cover them.
+
+## Expected value
+
+Every resource an `https://` page loads should also use `https://`, or a scheme-relative URL that inherits the page's own scheme:
+
+```html
+<img src="https://example.com/logo.png">
+<img src="//example.com/logo.png">
+```
+
+## What mamori checks
+
+The `src`/`href` attribute of every `img`, `script`, `link`, `iframe`, `audio`, and `video` tag in the response body, for `https://` targets only — an `http://` target has no TLS guarantee for mixed content to undermine, so it isn't checked. Each reference that starts with `http://` is reported as a medium-severity `WEAK` finding; a page can produce multiple findings, one per insecure reference. A page with no insecure references produces no findings — there's no `PASS` case, mirroring how the banner disclosure check treats absence as the desired state.
+
+## Further reading
+
+- [MDN: Mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)

--- a/site/checks/mixed-content.md
+++ b/site/checks/mixed-content.md
@@ -21,7 +21,11 @@ Every resource an `https://` page loads should also use `https://`, or a scheme-
 
 ## What mamori checks
 
-The `src`/`href` attribute of every `img`, `script`, `link`, `iframe`, `audio`, and `video` tag in the response body, for `https://` targets only — an `http://` target has no TLS guarantee for mixed content to undermine, so it isn't checked. Each reference that starts with `http://` is reported as a medium-severity `WEAK` finding; a page can produce multiple findings, one per insecure reference. A page with no insecure references produces no findings — there's no `PASS` case, mirroring how the banner disclosure check treats absence as the desired state.
+The `src`/`href` attribute of every `img`, `script`, `link`, `iframe`, `audio`, and `video` tag in the response body, for `https://` targets only — an `http://` target has no TLS guarantee for mixed content to undermine, so it isn't checked. Only a successful (`2xx`), HTML response is scanned; an error page, redirect, or non-HTML body (JSON, binary) is skipped, since it isn't the page mamori was asked to check. For `link`, only `rel` values the browser actually fetches count (`stylesheet`, `icon`, `apple-touch-icon`, `manifest`, `preload`, `prefetch`, `prerender`) — metadata-only relations like `canonical` or `alternate` are never dereferenced, so flagging them would be a false positive. Each reference that starts with `http://` is reported as a medium-severity `WEAK` finding; a page can produce multiple findings, one per insecure reference. A page with no insecure references produces no findings — there's no `PASS` case, mirroring how the banner disclosure check treats absence as the desired state.
+
+mamori reads at most 5MB of the response body — insecure references live in early markup, so a cap keeps a huge or slow-drip response from costing unbounded memory.
+
+If the body can't be fetched after the header checks already succeeded (e.g. a transient failure on the follow-up request), mamori reports a single `ERROR` finding for Mixed Content rather than silently reporting zero findings, so "checked and clean" is never confused with "the check didn't run".
 
 ## Further reading
 

--- a/site/index.md
+++ b/site/index.md
@@ -17,3 +17,4 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `Set-Cookie` | high / medium | [docs](checks/set-cookie) |
 | `Permissions-Policy` | medium | [docs](checks/permissions-policy) |
 | `Server` / `X-Powered-By` | low | [docs](checks/banner-disclosure) |
+| Mixed Content | medium | [docs](checks/mixed-content) |


### PR DESCRIPTION
## Summary
- For `https://` targets, fetches the response body (GET) and scans it with `golang.org/x/net/html` for `src`/`href` references on `img`/`script`/`link`/`iframe`/`audio`/`video` tags that load over plain `http://`. Each insecure reference is a medium-severity `WEAK` finding; a clean page produces none.
- Adds a `BodyChecker` interface (`Check(io.Reader) []Finding`) alongside the existing header `Checker`, with `DefaultBodyCheckers()` returning `[]BodyChecker{MixedContentChecker{}}`, threaded through `Scan`/`scanTarget` — so mixed-content checking only runs when explicitly configured and `DefaultCheckers()` continues to fully describe the header checks.
- `<link>` is only flagged for `rel` values the browser actually fetches (`stylesheet`, `icon`, `apple-touch-icon`, `manifest`, `preload`, `prefetch`, `prerender`) — metadata relations like `canonical`/`alternate` are ignored to avoid false positives.
- Reuses the body from `fetchHeaders`' GET fallback (when a target rejects HEAD) instead of issuing a second GET; caps the body read at 5MB via `io.LimitReader`; and skips non-2xx or non-HTML responses so an error/interstitial page's own assets aren't misattributed to the scanned target.
- A body-fetch failure (after the header fetch already succeeded) is reported as its own `ERROR` finding rather than silently omitted, so zero Mixed Content findings always means "checked and clean."
- Adds `site/checks/mixed-content.md` and an index row, following the existing per-checker docs convention.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race -cover` — all packages pass, `internal/scanner` at 96.2% coverage
- [x] Unit tests for `MixedContentChecker` (insecure/secure resources, all six tag types, protocol-relative URLs, scheme case-insensitivity, `link rel` filtering, embedded-whitespace scheme evasion)
- [x] Integration tests via `Scan` on `httptest.NewTLSServer` (finding surfaced with correct URL, skipped on `http://` targets, skipped when no `BodyCheckers` configured, skipped on non-HTML/non-2xx responses, GET-fallback body reuse verified via request count, body-size cap doesn't error on oversized bodies, body-fetch failure surfaces as an `ERROR` finding)
- [x] Reviewed via `/code-review` against `origin/main`; fixed all confirmed findings (interface bypass, double-GET, unbounded body, missing content-type/status gating, `link rel` false positives, URL-scheme evasion via embedded whitespace)

Closes #50

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*