### PR TITLE
feat(scanner): add Subresource Integrity (SRI) checker

### DIFF
--- a/cmd/mamori/main.go
+++ b/cmd/mamori/main.go
@@ -54,7 +54,7 @@ func run(args []string, stdin io.Reader, out io.Writer) error {
 		return err
 	}
 	client := &http.Client{Timeout: cfg.Timeout}
-	findings := scanner.Scan(context.Background(), client, scanner.DefaultCheckers(), urls, cfg.Workers)
+	findings := scanner.Scan(context.Background(), client, scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), urls, cfg.Workers)
 	if err := reporterFor(cfg.Output).Report(findings, out); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/PhyberApex/mamori
 go 1.25.2
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require golang.org/x/net v0.58.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
+golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -10,7 +10,7 @@ import (
 // Scan fans the URLs out to a fixed pool of worker goroutines. A failed
 // target becomes an error finding instead of aborting the scan, so every
 // target is accounted for in the report.
-func Scan(ctx context.Context, client *http.Client, checkers []Checker, urls []string, workers int) []Finding {
+func Scan(ctx context.Context, client *http.Client, checkers []Checker, bodyCheckers []BodyChecker, urls []string, workers int) []Finding {
 	jobs := make(chan int)
 	// Each worker writes only to its own job's index, so the slice needs no
 	// mutex: distinct goroutines never touch the same element, and wg.Wait()
@@ -27,7 +27,7 @@ func Scan(ctx context.Context, client *http.Client, checkers []Checker, urls []s
 			// Ranging over a channel keeps receiving until it is closed,
 			// which is how each worker knows there is no more work.
 			for i := range jobs {
-				perTarget[i] = scanTarget(ctx, client, checkers, urls[i])
+				perTarget[i] = scanTarget(ctx, client, checkers, bodyCheckers, urls[i])
 			}
 		}()
 	}
@@ -46,12 +46,30 @@ func Scan(ctx context.Context, client *http.Client, checkers []Checker, urls []s
 	return findings
 }
 
-func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, url string) []Finding {
-	headers, err := fetchHeaders(ctx, client, url)
-	if err != nil {
-		return []Finding{{URL: url, Status: StatusError, Message: err.Error()}}
+// scanTarget only pays for a body download when a BodyChecker actually needs
+// one: with none configured it keeps the HEAD-preferring fetchHeaders path,
+// same as before body checks existed.
+func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, bodyCheckers []BodyChecker, url string) []Finding {
+	var headers http.Header
+	var findings []Finding
+
+	if len(bodyCheckers) == 0 {
+		h, err := fetchHeaders(ctx, client, url)
+		if err != nil {
+			return []Finding{{URL: url, Status: StatusError, Message: err.Error()}}
+		}
+		headers = h
+		findings = RunAll(checkers, headers)
+	} else {
+		h, body, err := fetchBody(ctx, client, url)
+		if err != nil {
+			return []Finding{{URL: url, Status: StatusError, Message: err.Error()}}
+		}
+		headers = h
+		findings = RunAll(checkers, headers)
+		findings = append(findings, RunAllBody(bodyCheckers, body, url)...)
 	}
-	findings := RunAll(checkers, headers)
+
 	for i := range findings {
 		findings[i].URL = url
 	}
@@ -70,6 +88,26 @@ func fetchHeaders(ctx context.Context, client *http.Client, url string) (http.He
 		}
 	}
 	return headers, nil
+}
+
+// fetchBody always issues a GET, since body checkers need the body itself
+// and there's no cheaper request that would provide it.
+func fetchBody(ctx context.Context, client *http.Client, url string) (http.Header, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp.Header, body, nil
 }
 
 func doRequest(ctx context.Context, client *http.Client, method, url string) (http.Header, int, error) {

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -51,7 +51,7 @@ func Scan(ctx context.Context, client *http.Client, checkers []Checker, bodyChec
 // same as before body checks existed.
 func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, bodyCheckers []BodyChecker, url string) []Finding {
 	var headers http.Header
-	var findings []Finding
+	var bodyFindings []Finding
 
 	if len(bodyCheckers) == 0 {
 		h, err := fetchHeaders(ctx, client, url)
@@ -59,17 +59,16 @@ func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, bo
 			return []Finding{{URL: url, Status: StatusError, Message: err.Error()}}
 		}
 		headers = h
-		findings = RunAll(checkers, headers)
 	} else {
 		h, body, err := fetchBody(ctx, client, url)
 		if err != nil {
 			return []Finding{{URL: url, Status: StatusError, Message: err.Error()}}
 		}
 		headers = h
-		findings = RunAll(checkers, headers)
-		findings = append(findings, RunAllBody(bodyCheckers, body, url)...)
+		bodyFindings = RunAllBody(bodyCheckers, body, url)
 	}
 
+	findings := append(RunAll(checkers, headers), bodyFindings...)
 	for i := range findings {
 		findings[i].URL = url
 	}

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -52,20 +52,19 @@ func Scan(ctx context.Context, client *http.Client, checkers []Checker, bodyChec
 func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, bodyCheckers []BodyChecker, url string) []Finding {
 	var headers http.Header
 	var bodyFindings []Finding
+	var err error
 
 	if len(bodyCheckers) == 0 {
-		h, err := fetchHeaders(ctx, client, url)
-		if err != nil {
-			return []Finding{{URL: url, Status: StatusError, Message: err.Error()}}
-		}
-		headers = h
+		headers, err = fetchHeaders(ctx, client, url)
 	} else {
-		h, body, err := fetchBody(ctx, client, url)
-		if err != nil {
-			return []Finding{{URL: url, Status: StatusError, Message: err.Error()}}
+		var body []byte
+		headers, body, err = fetchBody(ctx, client, url)
+		if err == nil {
+			bodyFindings = RunAllBody(bodyCheckers, body, url)
 		}
-		headers = h
-		bodyFindings = RunAllBody(bodyCheckers, body, url)
+	}
+	if err != nil {
+		return []Finding{{URL: url, Status: StatusError, Message: err.Error()}}
 	}
 
 	findings := append(RunAll(checkers, headers), bodyFindings...)
@@ -89,6 +88,12 @@ func fetchHeaders(ctx context.Context, client *http.Client, url string) (http.He
 	return headers, nil
 }
 
+// maxBodyBytes caps how much of a response body fetchBody will buffer, so a
+// hostile or misconfigured target can't exhaust memory by returning an
+// unbounded body. Body checkers only look at the head of the document
+// (script/link tags), so a truncated body still yields usable findings.
+const maxBodyBytes = 10 * 1024 * 1024 // 10 MiB
+
 // fetchBody always issues a GET, since body checkers need the body itself
 // and there's no cheaper request that would provide it.
 func fetchBody(ctx context.Context, client *http.Client, url string) (http.Header, []byte, error) {
@@ -102,7 +107,7 @@ func fetchBody(ctx context.Context, client *http.Client, url string) (http.Heade
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -25,7 +25,7 @@ func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), []string{srv.URL}, 1)
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, []string{srv.URL}, 1)
 	if len(findings) != 6 {
 		t.Fatalf("Scan() returned %d findings, want 6", len(findings))
 	}
@@ -73,13 +73,63 @@ func TestScanFallsBackToGETWhenHEADRejected(t *testing.T) {
 	assertAllStatus(t, findings, scanner.StatusPass)
 }
 
+func TestScanSkipsBodyFetchWhenNoBodyCheckersConfigured(t *testing.T) {
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+	}))
+	t.Cleanup(srv.Close)
+
+	scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, []string{srv.URL}, 1)
+	if gotMethod != http.MethodHead {
+		t.Errorf("request method = %q, want %q (HEAD should be tried first when no body checkers are configured)", gotMethod, http.MethodHead)
+	}
+}
+
+func TestScanRunsBodyCheckersWhenConfigured(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<script src="https://cdn.example.net/app.js"></script>`))
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.Scan(t.Context(), srv.Client(), nil, scanner.DefaultBodyCheckers(), []string{srv.URL}, 1)
+	if len(findings) != 1 {
+		t.Fatalf("Scan() returned %d findings, want 1", len(findings))
+	}
+	f := findings[0]
+	if f.Status != scanner.StatusWeak {
+		t.Errorf("Status = %q, want %q", f.Status, scanner.StatusWeak)
+	}
+	if f.URL != srv.URL {
+		t.Errorf("URL = %q, want %q", f.URL, srv.URL)
+	}
+}
+
+func TestScanCombinesHeaderAndBodyCheckerFindings(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		_, _ = w.Write([]byte(`<script src="https://cdn.example.net/app.js"></script>`))
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.Scan(t.Context(), srv.Client(), []scanner.Checker{scanner.ContentTypeOptionsChecker{}}, scanner.DefaultBodyCheckers(), []string{srv.URL}, 1)
+	if len(findings) != 2 {
+		t.Fatalf("Scan() returned %d findings, want 2 (1 header + 1 body)", len(findings))
+	}
+	for _, f := range findings {
+		if f.URL != srv.URL {
+			t.Errorf("finding %s has URL %q, want %q", f.Header, f.URL, srv.URL)
+		}
+	}
+}
+
 func TestScanCoversMultipleURLs(t *testing.T) {
 	srvA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	t.Cleanup(srvA.Close)
 	srvB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	t.Cleanup(srvB.Close)
 
-	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), []string{srvA.URL, srvB.URL}, 2)
+	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), nil, []string{srvA.URL, srvB.URL}, 2)
 	if len(findings) != 12 {
 		t.Fatalf("Scan() returned %d findings, want 12 (6 per URL)", len(findings))
 	}
@@ -90,7 +140,7 @@ func TestScanUnreachableTargetYieldsErrorFinding(t *testing.T) {
 	unreachable := srv.URL
 	srv.Close()
 
-	findings := scanner.Scan(t.Context(), http.DefaultClient, scanner.DefaultCheckers(), []string{unreachable}, 1)
+	findings := scanner.Scan(t.Context(), http.DefaultClient, scanner.DefaultCheckers(), nil, []string{unreachable}, 1)
 	if len(findings) != 1 {
 		t.Fatalf("Scan() returned %d findings, want 1 error finding", len(findings))
 	}
@@ -117,7 +167,7 @@ func TestScanServerTimeoutYieldsErrorFinding(t *testing.T) {
 	})
 
 	client := &http.Client{Timeout: 50 * time.Millisecond}
-	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), []string{srv.URL}, 1)
+	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), nil, []string{srv.URL}, 1)
 	if len(findings) != 1 {
 		t.Fatalf("Scan() returned %d findings, want 1 error finding", len(findings))
 	}
@@ -137,7 +187,7 @@ func TestScanReportsAllTargetsDespiteFailures(t *testing.T) {
 	deadURL := dead.URL
 	dead.Close()
 
-	findings := scanner.Scan(t.Context(), http.DefaultClient, scanner.DefaultCheckers(), []string{deadURL, healthy.URL}, 2)
+	findings := scanner.Scan(t.Context(), http.DefaultClient, scanner.DefaultCheckers(), nil, []string{deadURL, healthy.URL}, 2)
 
 	byURL := map[string][]scanner.Finding{}
 	for _, f := range findings {
@@ -163,7 +213,7 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 
 	client := &http.Client{Timeout: 5 * time.Second}
 	urls := []string{srv.URL + "/a", srv.URL + "/b", srv.URL + "/c"}
-	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), urls, targets)
+	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), nil, urls, targets)
 
 	assertAllStatus(t, findings, scanner.StatusMissing)
 	if len(findings) != targets*6 {
@@ -194,7 +244,7 @@ func TestScanBoundsConcurrencyToPoolSize(t *testing.T) {
 	for i := range urls {
 		urls[i] = srv.URL + "/" + string(rune('a'+i))
 	}
-	scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), urls, workers)
+	scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, urls, workers)
 
 	if p := peak.Load(); p > workers {
 		t.Errorf("peak concurrent requests = %d, want at most %d", p, workers)
@@ -206,7 +256,7 @@ func TestScanPreservesTargetOrder(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	urls := []string{srv.URL + "/a", srv.URL + "/b", srv.URL + "/c"}
-	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), urls, 3)
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, urls, 3)
 
 	var seen []string
 	for _, f := range findings {

--- a/internal/scanner/sri.go
+++ b/internal/scanner/sri.go
@@ -75,7 +75,7 @@ func sriFinding(n *html.Node, base *url.URL) *Finding {
 	case "script":
 		attrName = "src"
 	case "link":
-		if !hasAttrValue(n, "rel", "stylesheet") {
+		if !hasRelValue(n, "stylesheet") {
 			return nil
 		}
 		attrName = "href"
@@ -130,7 +130,18 @@ func hasAttr(n *html.Node, key string) bool {
 	return ok && strings.TrimSpace(v) != ""
 }
 
-func hasAttrValue(n *html.Node, key, want string) bool {
-	v, ok := attrValue(n, key)
-	return ok && strings.EqualFold(strings.TrimSpace(v), want)
+// hasRelValue reports whether want is one of the link's rel keywords: rel is
+// spec'd as a space-separated token list (e.g. rel="preload stylesheet"), not
+// a single value, so an exact-string match would miss valid stylesheet links.
+func hasRelValue(n *html.Node, want string) bool {
+	v, ok := attrValue(n, "rel")
+	if !ok {
+		return false
+	}
+	for _, token := range strings.Fields(v) {
+		if strings.EqualFold(token, want) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/scanner/sri.go
+++ b/internal/scanner/sri.go
@@ -1,0 +1,136 @@
+package scanner
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// BodyChecker inspects the parsed HTML response body, unlike Checker which
+// only inspects headers. Judging Subresource Integrity requires resolving
+// each script/link tag's URL against the page's own origin, so a BodyChecker
+// needs the target URL alongside the body.
+type BodyChecker interface {
+	CheckBody(body []byte, targetURL string) []Finding
+}
+
+func DefaultBodyCheckers() []BodyChecker {
+	return []BodyChecker{SRIChecker{}}
+}
+
+func RunAllBody(checkers []BodyChecker, body []byte, targetURL string) []Finding {
+	var findings []Finding
+	for _, c := range checkers {
+		findings = append(findings, c.CheckBody(body, targetURL)...)
+	}
+	return findings
+}
+
+const sriReference = "https://cheatsheetseries.owasp.org/cheatsheets/Subresource_Integrity_Cheat_Sheet.html"
+
+// SRIChecker flags <script src> and <link rel="stylesheet" href> tags that
+// load a cross-origin resource without an integrity attribute. Subresource
+// Integrity lets the browser verify a fetched resource against a known hash
+// before executing/applying it, which matters when that resource comes from
+// somewhere the page owner doesn't fully control (e.g. a third-party CDN).
+// Same-origin resources are served by the site itself and conventionally
+// don't need it.
+type SRIChecker struct{}
+
+func (SRIChecker) CheckBody(body []byte, targetURL string) []Finding {
+	base, err := url.Parse(targetURL)
+	if err != nil {
+		return nil
+	}
+	doc, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return nil
+	}
+
+	var findings []Finding
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			if f := sriFinding(n, base); f != nil {
+				findings = append(findings, *f)
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+	return findings
+}
+
+// sriFinding judges a single element, returning nil for anything that isn't
+// an in-scope tag, has no resource reference, is already covered by
+// integrity, or resolves same-origin.
+func sriFinding(n *html.Node, base *url.URL) *Finding {
+	var attrName string
+	switch n.Data {
+	case "script":
+		attrName = "src"
+	case "link":
+		if !hasAttrValue(n, "rel", "stylesheet") {
+			return nil
+		}
+		attrName = "href"
+	default:
+		return nil
+	}
+
+	ref, ok := attrValue(n, attrName)
+	if !ok || strings.TrimSpace(ref) == "" {
+		return nil
+	}
+	if hasAttr(n, "integrity") {
+		return nil
+	}
+	if !isCrossOrigin(base, ref) {
+		return nil
+	}
+
+	return &Finding{
+		Header:    fmt.Sprintf("<%s %s=%q>", n.Data, attrName, ref),
+		Status:    StatusWeak,
+		Severity:  SeverityLow,
+		Reference: sriReference,
+		Message:   fmt.Sprintf("%s=%q is loaded cross-origin without an integrity attribute", attrName, ref),
+	}
+}
+
+// isCrossOrigin resolves ref against base the way a browser would (handling
+// relative paths and protocol-relative URLs alike) and compares scheme+host,
+// which is what determines origin for SRI purposes.
+func isCrossOrigin(base *url.URL, ref string) bool {
+	resolved, err := base.Parse(ref)
+	if err != nil {
+		return false
+	}
+	return !strings.EqualFold(resolved.Scheme, base.Scheme) || !strings.EqualFold(resolved.Host, base.Host)
+}
+
+func attrValue(n *html.Node, key string) (string, bool) {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val, true
+		}
+	}
+	return "", false
+}
+
+// hasAttr reports whether key is present with a non-blank value: a blank
+// integrity="" attribute provides no verification, same as omitting it.
+func hasAttr(n *html.Node, key string) bool {
+	v, ok := attrValue(n, key)
+	return ok && strings.TrimSpace(v) != ""
+}
+
+func hasAttrValue(n *html.Node, key, want string) bool {
+	v, ok := attrValue(n, key)
+	return ok && strings.EqualFold(strings.TrimSpace(v), want)
+}

--- a/internal/scanner/sri_test.go
+++ b/internal/scanner/sri_test.go
@@ -1,0 +1,95 @@
+package scanner_test
+
+import (
+	"testing"
+
+	"github.com/PhyberApex/mamori/internal/scanner"
+)
+
+const sriTargetURL = "https://example.com/"
+
+func TestSRICheckerFlagsCrossOriginWithoutIntegrity(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+	}{
+		{"script src", `<script src="https://cdn.example.net/app.js"></script>`},
+		{"link stylesheet href", `<link rel="stylesheet" href="https://cdn.example.net/app.css">`},
+		{"protocol-relative URL", `<script src="//cdn.example.net/app.js"></script>`},
+		{"blank integrity treated as missing", `<script src="https://cdn.example.net/app.js" integrity=""></script>`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.SRIChecker{}.CheckBody([]byte(tt.html), sriTargetURL)
+			if len(findings) != 1 {
+				t.Fatalf("CheckBody() returned %d findings, want 1", len(findings))
+			}
+			f := findings[0]
+			if f.Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", f.Status, scanner.StatusWeak)
+			}
+			if f.Severity != scanner.SeverityLow {
+				t.Errorf("Severity = %q, want %q", f.Severity, scanner.SeverityLow)
+			}
+			if f.Reference == "" {
+				t.Error("Reference is empty, want a docs URL")
+			}
+			if f.Message == "" {
+				t.Error("Message is empty")
+			}
+		})
+	}
+}
+
+func TestSRICheckerIgnoresSafeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+	}{
+		{"same-origin absolute script", `<script src="https://example.com/app.js"></script>`},
+		{"same-origin relative script", `<script src="/app.js"></script>`},
+		{"cross-origin script with integrity", `<script src="https://cdn.example.net/app.js" integrity="sha384-abc123"></script>`},
+		{"cross-origin link with integrity", `<link rel="stylesheet" href="https://cdn.example.net/app.css" integrity="sha384-abc123">`},
+		{"non-stylesheet link", `<link rel="icon" href="https://cdn.example.net/favicon.ico">`},
+		{"script with no src", `<script>console.log("inline")</script>`},
+		{"no script or link tags", `<html><body><p>hello</p></body></html>`},
+		{"empty body", ``},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.SRIChecker{}.CheckBody([]byte(tt.html), sriTargetURL)
+			if len(findings) != 0 {
+				t.Fatalf("CheckBody() returned %d findings, want 0: %+v", len(findings), findings)
+			}
+		})
+	}
+}
+
+func TestSRICheckerReportsEachOffendingTagIndependently(t *testing.T) {
+	body := `
+		<script src="https://cdn.example.net/a.js"></script>
+		<script src="/same-origin.js"></script>
+		<link rel="stylesheet" href="https://cdn.example.net/b.css">
+	`
+	findings := scanner.SRIChecker{}.CheckBody([]byte(body), sriTargetURL)
+	if len(findings) != 2 {
+		t.Fatalf("CheckBody() returned %d findings, want 2", len(findings))
+	}
+}
+
+func TestSRICheckerHandlesUnparseableTargetURL(t *testing.T) {
+	findings := scanner.SRIChecker{}.CheckBody([]byte(`<script src="https://cdn.example.net/a.js"></script>`), "://not-a-url")
+	if findings != nil {
+		t.Fatalf("CheckBody() with an unparseable target URL = %+v, want nil", findings)
+	}
+}
+
+func TestRunAllBodyFansOutAcrossDefaultBodyCheckers(t *testing.T) {
+	body := []byte(`<script src="https://cdn.example.net/a.js"></script>`)
+	findings := scanner.RunAllBody(scanner.DefaultBodyCheckers(), body, sriTargetURL)
+	if len(findings) != 1 {
+		t.Fatalf("RunAllBody() returned %d findings, want 1", len(findings))
+	}
+}

--- a/internal/scanner/sri_test.go
+++ b/internal/scanner/sri_test.go
@@ -16,6 +16,7 @@ func TestSRICheckerFlagsCrossOriginWithoutIntegrity(t *testing.T) {
 		{"script src", `<script src="https://cdn.example.net/app.js"></script>`},
 		{"link stylesheet href", `<link rel="stylesheet" href="https://cdn.example.net/app.css">`},
 		{"protocol-relative URL", `<script src="//cdn.example.net/app.js"></script>`},
+		{"link with multiple rel tokens", `<link rel="preload stylesheet" href="https://cdn.example.net/app.css">`},
 		{"blank integrity treated as missing", `<script src="https://cdn.example.net/app.js" integrity=""></script>`},
 	}
 

--- a/site/checks/subresource-integrity.md
+++ b/site/checks/subresource-integrity.md
@@ -1,0 +1,30 @@
+---
+layout: page
+title: Subresource Integrity
+permalink: /checks/subresource-integrity
+---
+
+**Severity:** low
+
+## What it does
+
+Checks `<script src>` and `<link rel="stylesheet" href>` tags in the response body for cross-origin resources loaded without an `integrity` attribute. Subresource Integrity (SRI) lets the browser verify a fetched resource against a known hash before executing or applying it, so a compromised third-party host (e.g. a CDN) can't silently swap in malicious script or CSS.
+
+## Expected value
+
+Cross-origin resources should carry an `integrity` attribute with a hash of the expected content:
+
+```html
+<script src="https://cdn.example.com/lib.js"
+        integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"
+        crossorigin="anonymous"></script>
+```
+
+## What mamori checks
+
+Fetches and parses the response body with the standard HTML parser, then inspects every `<script>` and `<link rel="stylesheet">` tag. A tag is flagged as a low-severity `WEAK` finding when its resource URL resolves to a different origin (scheme, host, or port) than the page itself and it has no `integrity` attribute (or a blank one). Same-origin resources are not flagged — they're served by the site itself and conventionally don't need SRI.
+
+## Further reading
+
+- [MDN: Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
+- [OWASP: Subresource Integrity Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Subresource_Integrity_Cheat_Sheet.html)

--- a/site/checks/subresource-integrity.md
+++ b/site/checks/subresource-integrity.md
@@ -22,7 +22,7 @@ Cross-origin resources should carry an `integrity` attribute with a hash of the 
 
 ## What mamori checks
 
-Fetches and parses the response body with the standard HTML parser, then inspects every `<script>` and `<link rel="stylesheet">` tag. A tag is flagged as a low-severity `WEAK` finding when its resource URL resolves to a different origin (scheme, host, or port) than the page itself and it has no `integrity` attribute (or a blank one). Same-origin resources are not flagged — they're served by the site itself and conventionally don't need SRI.
+Fetches and parses the response body with Go's HTML parser, then inspects every `<script>` and `<link rel="stylesheet">` tag. A tag is flagged as a low-severity `WEAK` finding when its resource URL resolves to a different origin (scheme, host, or port) than the page itself and it has no `integrity` attribute (or a blank one). Same-origin resources are not flagged — they're served by the site itself and conventionally don't need SRI.
 
 ## Further reading
 

--- a/site/index.md
+++ b/site/index.md
@@ -17,3 +17,4 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `Set-Cookie` | high / medium | [docs](checks/set-cookie) |
 | `Permissions-Policy` | medium | [docs](checks/permissions-policy) |
 | `Server` / `X-Powered-By` | low | [docs](checks/banner-disclosure) |
+| `<script>` / `<link>` (SRI) | low | [docs](checks/subresource-integrity) |


### PR DESCRIPTION
## Summary

- Adds a `SRIChecker` that parses the HTML response body and flags `<script src>` / `<link rel=stylesheet href>` tags whose resource resolves to a different origin than the target page and lack an `integrity` attribute (a blank `integrity=""` counts as missing). Same-origin resources are not flagged.
- Adds the body-fetch plumbing this required: a new `BodyChecker` interface (parallel to the existing header-only `Checker`), `RunAllBody`/`DefaultBodyCheckers`, and a `fetchBody` GET path in the scanner. Header-only scans keep the existing HEAD-preferring `fetchHeaders` path — a body is only fetched when body checkers are actually configured, so this is opt-in cost, not a behavior change for existing checks.
- Uses `golang.org/x/net/html` to parse (the closest thing to "stdlib net/html" — Go's actual standard library has no HTML parser).
- Adds the `docs/checks/subresource-integrity.md` reference page and a row in `site/index.md`, matching the existing per-check doc convention.

## Why

Closes #51. Cross-origin `<script>`/`<link>` resources loaded without SRI let a compromised third-party host (e.g. a CDN) silently swap in malicious content with no way for the browser to detect it.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race` (all packages pass)
- [x] `gofmt -l .` clean
- [x] New unit tests for `SRIChecker.CheckBody` covering: cross-origin script/link without integrity, protocol-relative URLs, blank `integrity=""`, multi-token `rel` (e.g. `rel="preload stylesheet"`), same-origin (absolute/relative) resources, resources with integrity, non-stylesheet links, inline scripts, malformed target URL, empty body.
- [x] New `Scan`-level integration tests confirming: body checkers are skipped (HEAD-only) when none are configured, body checkers run and produce findings with the correct URL when configured, and header + body findings combine correctly.
- [x] Ran `/mattpocock-skills:code-review` against `origin/main` (Standards + Spec axes); addressed both judgement-call findings (hoisted duplicated `RunAll` call, fixed `rel` to match as a token list instead of an exact string).

Closes #51

> Opened by Kongroo, karakuri's Projects agent — Stage: implement