### PR TITLE
feat(scanner): add security.txt checker

### DIFF
--- a/cmd/mamori/main_test.go
+++ b/cmd/mamori/main_test.go
@@ -45,7 +45,7 @@ func headerServer(t *testing.T, headers map[string]string) string {
 	transport := original.(*http.Transport).Clone()
 	pool := x509.NewCertPool()
 	pool.AddCert(srv.Certificate())
-	transport.TLSClientConfig = &tls.Config{RootCAs: pool}
+	transport.TLSClientConfig = &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
 	http.DefaultTransport = transport
 	t.Cleanup(func() { http.DefaultTransport = original })
 

--- a/cmd/mamori/main_test.go
+++ b/cmd/mamori/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"io"
 	"net/http"
@@ -23,12 +25,27 @@ func strongHeaders() map[string]string {
 
 func headerServer(t *testing.T, headers map[string]string) string {
 	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// TLS: the security.txt probe forces https regardless of target scheme
+	// (RFC 9116), so a plain-http server would fail that probe outright.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for name, value := range headers {
 			w.Header().Set(name, value)
 		}
 	}))
 	t.Cleanup(srv.Close)
+
+	// run() builds its own http.Client from http.DefaultTransport rather
+	// than accepting one, so trust this server's self-signed cert there for
+	// the test's duration; every test in this file runs sequentially, so
+	// there's no cross-test race on the swap.
+	original := http.DefaultTransport
+	transport := original.(*http.Transport).Clone()
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	transport.TLSClientConfig = &tls.Config{RootCAs: pool}
+	http.DefaultTransport = transport
+	t.Cleanup(func() { http.DefaultTransport = original })
+
 	return srv.URL
 }
 

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -52,6 +52,7 @@ func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, ur
 		return []Finding{{URL: url, Status: StatusError, Message: err.Error()}}
 	}
 	findings := RunAll(checkers, headers)
+	findings = append(findings, SecurityTxtChecker{}.Check(ctx, client, url)...)
 	for i := range findings {
 		findings[i].URL = url
 	}

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -26,8 +26,8 @@ func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
 	t.Cleanup(srv.Close)
 
 	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), []string{srv.URL}, 1)
-	if len(findings) != 6 {
-		t.Fatalf("Scan() returned %d findings, want 6", len(findings))
+	if len(findings) != 7 {
+		t.Fatalf("Scan() returned %d findings, want 7", len(findings))
 	}
 	for _, f := range findings {
 		if f.URL != srv.URL {
@@ -56,7 +56,11 @@ func TestScanAllHeadersPresent(t *testing.T) {
 }
 
 func TestScanAllHeadersMissing(t *testing.T) {
-	findings := scanOne(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	findings := scanOne(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 404 so the security.txt probe reads as missing too, matching every
+		// other finding in this "nothing configured" scenario.
+		w.WriteHeader(http.StatusNotFound)
+	}))
 	assertAllStatus(t, findings, scanner.StatusMissing)
 }
 
@@ -80,8 +84,8 @@ func TestScanCoversMultipleURLs(t *testing.T) {
 	t.Cleanup(srvB.Close)
 
 	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), []string{srvA.URL, srvB.URL}, 2)
-	if len(findings) != 12 {
-		t.Fatalf("Scan() returned %d findings, want 12 (6 per URL)", len(findings))
+	if len(findings) != 14 {
+		t.Fatalf("Scan() returned %d findings, want 14 (7 per URL)", len(findings))
 	}
 }
 
@@ -146,8 +150,8 @@ func TestScanReportsAllTargetsDespiteFailures(t *testing.T) {
 	if got := len(byURL[deadURL]); got != 1 {
 		t.Errorf("dead target has %d findings, want 1 error finding", got)
 	}
-	if got := len(byURL[healthy.URL]); got != 6 {
-		t.Errorf("healthy target has %d findings, want 6", got)
+	if got := len(byURL[healthy.URL]); got != 7 {
+		t.Errorf("healthy target has %d findings, want 7", got)
 	}
 }
 
@@ -156,6 +160,14 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(targets)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The security.txt probe hits the same server on a fixed path outside
+		// this test's target-concurrency handshake; let it through without
+		// joining the wg synchronization, or the extra request per target
+		// would double-call wg.Done() and panic.
+		if r.URL.Path == "/.well-known/security.txt" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		wg.Done()
 		wg.Wait()
 	}))
@@ -166,8 +178,8 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), urls, targets)
 
 	assertAllStatus(t, findings, scanner.StatusMissing)
-	if len(findings) != targets*6 {
-		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*6)
+	if len(findings) != targets*7 {
+		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*7)
 	}
 }
 

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -22,7 +22,9 @@ var allSecurityHeaders = map[string]string{
 
 func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
 	t.Helper()
-	srv := httptest.NewServer(handler)
+	// TLS: the security.txt probe forces https regardless of target scheme
+	// (RFC 9116), so a plain-http server would fail that probe outright.
+	srv := httptest.NewTLSServer(handler)
 	t.Cleanup(srv.Close)
 
 	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), []string{srv.URL}, 1)
@@ -159,7 +161,9 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 	const targets = 3
 	var wg sync.WaitGroup
 	wg.Add(targets)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// TLS: the security.txt probe forces https regardless of target scheme
+	// (RFC 9116), so a plain-http server would fail that probe outright.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// The security.txt probe hits the same server on a fixed path outside
 		// this test's target-concurrency handshake; let it through without
 		// joining the wg synchronization, or the extra request per target
@@ -173,7 +177,8 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	client := &http.Client{Timeout: 5 * time.Second}
+	client := srv.Client()
+	client.Timeout = 5 * time.Second
 	urls := []string{srv.URL + "/a", srv.URL + "/b", srv.URL + "/c"}
 	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), urls, targets)
 

--- a/internal/scanner/securitytxt.go
+++ b/internal/scanner/securitytxt.go
@@ -1,0 +1,61 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const securityTxtReference = "https://www.rfc-editor.org/rfc/rfc9116"
+
+// SecurityTxtChecker probes RFC 9116's well-known security.txt path as a
+// request separate from the main target scan: unlike the header checkers, it
+// needs its own round trip rather than inspecting the response already
+// fetched for the target URL. This is a well-known, publicly-intended
+// discovery path (unlike arbitrary file probing), so it runs unconditionally
+// alongside the header checkers rather than needing an opt-in flag.
+type SecurityTxtChecker struct{}
+
+func (SecurityTxtChecker) Check(ctx context.Context, client *http.Client, target string) []Finding {
+	finding := Finding{
+		Header:    "/.well-known/security.txt",
+		Severity:  SeverityLow,
+		Reference: securityTxtReference,
+	}
+
+	probeURL, err := securityTxtURL(target)
+	if err != nil {
+		finding.Status = StatusError
+		finding.Message = err.Error()
+		return []Finding{finding}
+	}
+
+	_, status, err := doRequest(ctx, client, http.MethodGet, probeURL)
+	if err != nil {
+		finding.Status = StatusError
+		finding.Message = err.Error()
+		return []Finding{finding}
+	}
+	if status < 200 || status > 299 {
+		finding.Status = StatusMissing
+		return []Finding{finding}
+	}
+	finding.Status = StatusPass
+	return []Finding{finding}
+}
+
+// securityTxtURL resolves RFC 9116's fixed well-known path against target's
+// scheme and host, discarding any path/query/fragment target itself carries:
+// the well-known path is always root-relative, regardless of what path the
+// user asked to scan.
+func securityTxtURL(target string) (string, error) {
+	u, err := url.Parse(target)
+	if err != nil {
+		return "", fmt.Errorf("parsing target %q: %w", target, err)
+	}
+	u.Path = "/.well-known/security.txt"
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}

--- a/internal/scanner/securitytxt.go
+++ b/internal/scanner/securitytxt.go
@@ -46,14 +46,17 @@ func (SecurityTxtChecker) Check(ctx context.Context, client *http.Client, target
 }
 
 // securityTxtURL resolves RFC 9116's fixed well-known path against target's
-// scheme and host, discarding any path/query/fragment target itself carries:
-// the well-known path is always root-relative, regardless of what path the
-// user asked to scan.
+// host, discarding any path/query/fragment target itself carries: the
+// well-known path is always root-relative, regardless of what path the user
+// asked to scan. The scheme is forced to https regardless of target's own
+// scheme: RFC 9116 section 3 requires "the file access MUST use the
+// 'https' scheme".
 func securityTxtURL(target string) (string, error) {
 	u, err := url.Parse(target)
 	if err != nil {
 		return "", fmt.Errorf("parsing target %q: %w", target, err)
 	}
+	u.Scheme = "https"
 	u.Path = "/.well-known/security.txt"
 	u.RawQuery = ""
 	u.Fragment = ""

--- a/internal/scanner/securitytxt.go
+++ b/internal/scanner/securitytxt.go
@@ -18,30 +18,26 @@ const securityTxtReference = "https://www.rfc-editor.org/rfc/rfc9116"
 type SecurityTxtChecker struct{}
 
 func (SecurityTxtChecker) Check(ctx context.Context, client *http.Client, target string) []Finding {
+	probeURL, err := securityTxtURL(target)
+	if err != nil {
+		return []Finding{{Status: StatusError, Message: err.Error()}}
+	}
+
+	_, status, err := doRequest(ctx, client, http.MethodGet, probeURL)
+	if err != nil {
+		return []Finding{{Status: StatusError, Message: err.Error()}}
+	}
+
 	finding := Finding{
 		Header:    "/.well-known/security.txt",
 		Severity:  SeverityLow,
 		Reference: securityTxtReference,
 	}
-
-	probeURL, err := securityTxtURL(target)
-	if err != nil {
-		finding.Status = StatusError
-		finding.Message = err.Error()
-		return []Finding{finding}
-	}
-
-	_, status, err := doRequest(ctx, client, http.MethodGet, probeURL)
-	if err != nil {
-		finding.Status = StatusError
-		finding.Message = err.Error()
-		return []Finding{finding}
-	}
 	if status < 200 || status > 299 {
 		finding.Status = StatusMissing
-		return []Finding{finding}
+	} else {
+		finding.Status = StatusPass
 	}
-	finding.Status = StatusPass
 	return []Finding{finding}
 }
 

--- a/internal/scanner/securitytxt_test.go
+++ b/internal/scanner/securitytxt_test.go
@@ -1,0 +1,92 @@
+package scanner_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PhyberApex/mamori/internal/scanner"
+)
+
+func TestSecurityTxtCheckerProbesWellKnownPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	scanner.SecurityTxtChecker{}.Check(t.Context(), srv.Client(), srv.URL)
+
+	if gotPath != "/.well-known/security.txt" {
+		t.Errorf("probed path = %q, want %q", gotPath, "/.well-known/security.txt")
+	}
+}
+
+func TestSecurityTxtCheckerPassesOn2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.SecurityTxtChecker{}.Check(t.Context(), srv.Client(), srv.URL)
+	if len(findings) != 1 {
+		t.Fatalf("Check() returned %d findings, want 1", len(findings))
+	}
+
+	if findings[0].Status != scanner.StatusPass {
+		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
+	}
+	if findings[0].Reference == "" {
+		t.Error("Reference is empty, want a docs URL")
+	}
+}
+
+func TestSecurityTxtCheckerFlagsNon2xxAsMissing(t *testing.T) {
+	tests := []int{
+		http.StatusNotFound,
+		http.StatusMovedPermanently,
+		http.StatusInternalServerError,
+	}
+	for _, status := range tests {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+		}))
+
+		findings := scanner.SecurityTxtChecker{}.Check(t.Context(), srv.Client(), srv.URL)
+		if findings[0].Status != scanner.StatusMissing {
+			t.Errorf("status %d: Status = %q, want %q", status, findings[0].Status, scanner.StatusMissing)
+		}
+		srv.Close()
+	}
+}
+
+func TestSecurityTxtCheckerReportsErrorOnRequestFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	unreachable := srv.URL
+	srv.Close()
+
+	findings := scanner.SecurityTxtChecker{}.Check(t.Context(), http.DefaultClient, unreachable)
+
+	if findings[0].Status != scanner.StatusError {
+		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusError)
+	}
+	if findings[0].Message == "" {
+		t.Error("Message is empty, want the failure message")
+	}
+}
+
+func TestSecurityTxtCheckerIgnoresTargetPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	scanner.SecurityTxtChecker{}.Check(t.Context(), srv.Client(), srv.URL+"/some/deep/path?query=1")
+
+	if gotPath != "/.well-known/security.txt" {
+		t.Errorf("probed path = %q, want %q (target's own path/query must not leak in)", gotPath, "/.well-known/security.txt")
+	}
+}

--- a/internal/scanner/securitytxt_test.go
+++ b/internal/scanner/securitytxt_test.go
@@ -3,6 +3,7 @@ package scanner_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/PhyberApex/mamori/internal/scanner"
@@ -10,7 +11,7 @@ import (
 
 func TestSecurityTxtCheckerProbesWellKnownPath(t *testing.T) {
 	var gotPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -24,7 +25,7 @@ func TestSecurityTxtCheckerProbesWellKnownPath(t *testing.T) {
 }
 
 func TestSecurityTxtCheckerPassesOn2xx(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
@@ -49,7 +50,7 @@ func TestSecurityTxtCheckerFlagsNon2xxAsMissing(t *testing.T) {
 		http.StatusInternalServerError,
 	}
 	for _, status := range tests {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(status)
 		}))
 
@@ -78,7 +79,7 @@ func TestSecurityTxtCheckerReportsErrorOnRequestFailure(t *testing.T) {
 
 func TestSecurityTxtCheckerIgnoresTargetPath(t *testing.T) {
 	var gotPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -88,5 +89,23 @@ func TestSecurityTxtCheckerIgnoresTargetPath(t *testing.T) {
 
 	if gotPath != "/.well-known/security.txt" {
 		t.Errorf("probed path = %q, want %q (target's own path/query must not leak in)", gotPath, "/.well-known/security.txt")
+	}
+}
+
+func TestSecurityTxtCheckerForcesHTTPSScheme(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	// RFC 9116 section 3: "the file access MUST use the 'https' scheme".
+	// Rewrite the TLS server's own https URL to look like an http target;
+	// if the checker didn't force https, this would fail to reach the
+	// TLS-only server at all.
+	httpTarget := "http://" + strings.TrimPrefix(srv.URL, "https://")
+
+	findings := scanner.SecurityTxtChecker{}.Check(t.Context(), srv.Client(), httpTarget)
+	if findings[0].Status != scanner.StatusPass {
+		t.Errorf("Status = %q, want %q (probe should have used https despite an http:// target)", findings[0].Status, scanner.StatusPass)
 	}
 }

--- a/site/checks/security-txt.md
+++ b/site/checks/security-txt.md
@@ -23,7 +23,7 @@ Expires: 2027-01-01T00:00:00.000Z
 
 ## What mamori checks
 
-Whether `GET /.well-known/security.txt` on the target's scheme and host returns a 2xx status. Any non-2xx response (404, a redirect, a server error) is reported as a low-severity `MISSING` finding. This is a well-known, publicly-intended discovery path — unlike probing for arbitrary sensitive files — so the check always runs, with no opt-in required.
+Whether `GET /.well-known/security.txt` on the target's host returns a 2xx status. The request always uses `https`, regardless of the scheme the target was scanned with — RFC 9116 §3 requires "the file access MUST use the 'https' scheme" — so a target with no HTTPS support reports as `ERROR`, not `MISSING`. Any non-2xx response (404, a redirect, a server error) is reported as a low-severity `MISSING` finding. This is a well-known, publicly-intended discovery path — unlike probing for arbitrary sensitive files — so the check always runs, with no opt-in required.
 
 ## Further reading
 

--- a/site/checks/security-txt.md
+++ b/site/checks/security-txt.md
@@ -23,7 +23,7 @@ Expires: 2027-01-01T00:00:00.000Z
 
 ## What mamori checks
 
-Whether `GET /.well-known/security.txt` on the target's host returns a 2xx status. The request always uses `https`, regardless of the scheme the target was scanned with — RFC 9116 §3 requires "the file access MUST use the 'https' scheme" — so a target with no HTTPS support reports as `ERROR`, not `MISSING`. Any non-2xx response (404, a redirect, a server error) is reported as a low-severity `MISSING` finding. This is a well-known, publicly-intended discovery path — unlike probing for arbitrary sensitive files — so the check always runs, with no opt-in required.
+Whether `GET /.well-known/security.txt` on the target's host returns a 2xx status. The request always uses `https`, regardless of the scheme the target was scanned with — RFC 9116 §3 requires "the file access MUST use the 'https' scheme" — so a target with no HTTPS support reports as `ERROR`, not `MISSING`. Ordinary redirects are followed transparently; whatever response ultimately comes back (a 404, an unfollowed redirect, a server error) is what's judged — any final non-2xx status is reported as a low-severity `MISSING` finding. This is a well-known, publicly-intended discovery path — unlike probing for arbitrary sensitive files — so the check always runs, with no opt-in required.
 
 ## Further reading
 

--- a/site/checks/security-txt.md
+++ b/site/checks/security-txt.md
@@ -1,0 +1,31 @@
+---
+layout: page
+title: security.txt
+permalink: /checks/security-txt
+---
+
+**Severity:** low
+
+## What it does
+
+Checks for a `security.txt` file at the well-known path defined by [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116), `/.well-known/security.txt`. It tells security researchers how to report vulnerabilities they find on your site, instead of leaving them to guess an inbox or give up.
+
+Unlike the header checks, this probes a fixed path rather than inspecting the response already fetched for the target URL — a separate request, made against every target, whatever path was scanned.
+
+## Expected value
+
+A small text file at `/.well-known/security.txt`:
+
+```
+Contact: mailto:security@example.com
+Expires: 2027-01-01T00:00:00.000Z
+```
+
+## What mamori checks
+
+Whether `GET /.well-known/security.txt` on the target's scheme and host returns a 2xx status. Any non-2xx response (404, a redirect, a server error) is reported as a low-severity `MISSING` finding. This is a well-known, publicly-intended discovery path — unlike probing for arbitrary sensitive files — so the check always runs, with no opt-in required.
+
+## Further reading
+
+- [RFC 9116: A File Format to Aid in Security Vulnerability Disclosure](https://www.rfc-editor.org/rfc/rfc9116)
+- [securitytxt.org](https://securitytxt.org/)

--- a/site/index.md
+++ b/site/index.md
@@ -17,3 +17,4 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `Set-Cookie` | high / medium | [docs](checks/set-cookie) |
 | `Permissions-Policy` | medium | [docs](checks/permissions-policy) |
 | `Server` / `X-Powered-By` | low | [docs](checks/banner-disclosure) |
+| `/.well-known/security.txt` | low | [docs](checks/security-txt) |


### PR DESCRIPTION
## What

Adds `SecurityTxtChecker`, which probes `GET /.well-known/security.txt` (RFC 9116) as a request separate from the main target scan. Any non-2xx response is reported as a low-severity `missing` finding; a 2xx passes.

## Why

Per #54: security.txt tells researchers how to report vulnerabilities. Unlike arbitrary sensitive-file probing (#53), this is a well-known, publicly-intended discovery path, so it ships unconditionally — no opt-in flag.

## Implementation notes

- `SecurityTxtChecker.Check(ctx, client, target) []Finding` lives outside the existing header-based `Checker` interface (`Check(headers http.Header) []Finding`) since it needs its own HTTP round trip rather than inspecting headers already fetched for the target — but keeps the `[]Finding`-returning shape so callers compose it the same way as every other checker.
- Wired into `scanTarget` in `internal/scanner/scan.go`, always running alongside `RunAll(checkers, headers)`.
- Docs added at `site/checks/security-txt.md` and linked from `site/index.md`, matching the existing per-check reference pages.

## Test evidence

- New `internal/scanner/securitytxt_test.go`: probes the correct well-known path (ignoring the target's own path/query), passes on 2xx, flags 404/301/500 as missing, and reports request failures as `error`.
- Updated `internal/scanner/scan_test.go` finding-count assertions (6→7 findings per target) and adjusted the concurrency test's handler to keep the security.txt probe out of its `wg` synchronization handshake.
- `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l .`, and `golangci-lint run ./...` all pass clean.
- Ran a `/code-review`-style two-axis review (Standards + Spec) against `origin/main`; fixed the two Standards findings it surfaced (return type consistency, `Finding.Header` value clarity) before this PR.

Closes #54

> Opened by Kongroo, karakuri's Projects agent — Stage: implement