### PR TITLE
feat(scanner): add SARIF output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,16 @@ Full reference for every check mamori performs is available at
 |---|---|---|
 | `-workers` | `10` | number of concurrent scan workers |
 | `-timeout` | `10s` | HTTP request timeout (e.g. `5s`) |
-| `-o` | `terminal` | output format: `terminal` or `json` |
+| `-o` | `terminal` | output format: `terminal`, `json`, or `sarif` |
 | `-fail-on` | `none` | exit non-zero on findings at or above this severity: `low`, `medium`, `high`, or `none` |
 | `-config` | *(none)* | path to a YAML config file |
 
 `-o json` emits newline-delimited JSON, one finding per line.
+
+`-o sarif` emits a [SARIF 2.1.0](https://github.com/oasis-tcs/sarif-spec) log
+for GitHub code scanning / CI integration, with one result per non-pass
+finding; `Severity` maps to SARIF `level` as low→`note`, medium→`warning`,
+high→`error`.
 
 `-fail-on` gates the exit code on the scan's own findings, for use as a CI
 check. The default, `none`, never fails — the exit code stays `0` no matter

--- a/cmd/mamori/main.go
+++ b/cmd/mamori/main.go
@@ -71,6 +71,8 @@ func reporterFor(o config.Output) scanner.Reporter {
 	switch o {
 	case config.OutputJSON:
 		return scanner.JSONReporter{}
+	case config.OutputSarif:
+		return scanner.SarifReporter{}
 	default:
 		return scanner.TerminalReporter{}
 	}

--- a/cmd/mamori/main_test.go
+++ b/cmd/mamori/main_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -113,6 +116,41 @@ func TestRunFailOnEnvVar(t *testing.T) {
 	err := run([]string{url}, nil, io.Discard)
 	if !errors.Is(err, errFailThreshold) {
 		t.Errorf("run() with MAMORI_FAIL_ON=low returned %v, want errFailThreshold", err)
+	}
+}
+
+func TestRunEmitsSarifOutput(t *testing.T) {
+	url := headerServer(t, nil) // every header missing
+
+	var buf bytes.Buffer
+	if err := run([]string{"-o", "sarif", url}, nil, &buf); err != nil {
+		t.Fatalf("run() with -o sarif returned %v, want nil", err)
+	}
+
+	var doc struct {
+		Version string `json:"version"`
+		Runs    []struct {
+			Results []struct {
+				RuleID string `json:"ruleId"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, buf.String())
+	}
+	if doc.Version != "2.1.0" {
+		t.Errorf("version = %q, want %q", doc.Version, "2.1.0")
+	}
+	if len(doc.Runs) != 1 || len(doc.Runs[0].Results) == 0 {
+		t.Fatalf("got no SARIF results for a scan with missing headers\noutput:\n%s", buf.String())
+	}
+}
+
+func TestRunRejectsUnknownOutputFormat(t *testing.T) {
+	url := headerServer(t, strongHeaders())
+	err := run([]string{"-o", "xml", url}, nil, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "not a known output format") {
+		t.Errorf("run() with -o xml returned %v, want a known-output-format error", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Output string
 const (
 	OutputTerminal Output = "terminal"
 	OutputJSON     Output = "json"
+	OutputSarif    Output = "sarif"
 )
 
 const (
@@ -41,10 +42,10 @@ type Config struct {
 
 func parseOutput(v string) (Output, error) {
 	switch Output(v) {
-	case OutputTerminal, OutputJSON:
+	case OutputTerminal, OutputJSON, OutputSarif:
 		return Output(v), nil
 	}
-	return "", fmt.Errorf("%q is not a known output format (terminal, json)", v)
+	return "", fmt.Errorf("%q is not a known output format (terminal, json, sarif)", v)
 }
 
 // String and Set make *Output satisfy flag.Value, the stdlib's hook for
@@ -123,7 +124,7 @@ func registerFlags(cfg *Config) (*flag.FlagSet, *string) {
 	fs := flag.NewFlagSet("mamori", flag.ContinueOnError)
 	fs.IntVar(&cfg.Workers, "workers", cfg.Workers, "number of concurrent scan workers")
 	fs.DurationVar(&cfg.Timeout, "timeout", cfg.Timeout, "HTTP request timeout (e.g. 5s)")
-	fs.Var(&cfg.Output, "o", "output format: terminal or json")
+	fs.Var(&cfg.Output, "o", "output format: terminal, json, or sarif")
 	fs.Var(&cfg.FailOn, "fail-on", "exit non-zero on findings at or above this severity: low, medium, high, or none")
 	var configPath string
 	fs.StringVar(&configPath, "config", "", "path to YAML config file (env MAMORI_CONFIG; default: .mamori.yaml in the working directory if present)")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -118,6 +118,16 @@ func TestResolveRejectsNonPositiveWorkersFlag(t *testing.T) {
 	}
 }
 
+func TestResolveAcceptsSarifOutputFlag(t *testing.T) {
+	cfg, _, err := config.Resolve([]string{"-o", "sarif"}, noEnv)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.Output != config.OutputSarif {
+		t.Errorf("Output = %q, want %q from -o flag", cfg.Output, config.OutputSarif)
+	}
+}
+
 func TestResolveRejectsUnknownOutputFlag(t *testing.T) {
 	if _, _, err := config.Resolve([]string{"-o", "xml"}, noEnv); err == nil {
 		t.Error("Resolve() with -o xml returned nil error, want error")

--- a/internal/scanner/sarif.go
+++ b/internal/scanner/sarif.go
@@ -1,0 +1,157 @@
+package scanner
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// sarifSchemaURI pins the exact SARIF 2.1.0 schema document these reports
+// validate against, per oasis-tcs/sarif-spec.
+const sarifSchemaURI = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/Schemata/sarif-schema-2.1.0.json"
+
+type sarifLog struct {
+	Version string     `json:"version"`
+	Schema  string     `json:"$schema"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name           string      `json:"name"`
+	InformationURI string      `json:"informationUri"`
+	Rules          []sarifRule `json:"rules,omitempty"`
+}
+
+type sarifRule struct {
+	ID               string    `json:"id"`
+	ShortDescription sarifText `json:"shortDescription"`
+}
+
+type sarifText struct {
+	Text string `json:"text"`
+}
+
+type sarifResult struct {
+	RuleID    string          `json:"ruleId"`
+	Level     string          `json:"level"`
+	Message   sarifText       `json:"message"`
+	Locations []sarifLocation `json:"locations"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+// SarifReporter emits a SARIF 2.1.0 log (oasis-tcs/sarif-spec), the format
+// GitHub code scanning and similar CI tooling expect. Only non-pass findings
+// become results — a clean header carries no actionable location for a code
+// scanning UI to annotate.
+type SarifReporter struct{}
+
+func (SarifReporter) Report(findings []Finding, w io.Writer) error {
+	driver := sarifDriver{
+		Name:           "mamori",
+		InformationURI: "https://github.com/PhyberApex/mamori",
+	}
+	results := []sarifResult{}
+	seenRules := map[string]bool{}
+
+	for _, f := range findings {
+		if f.Status == StatusPass {
+			continue
+		}
+		ruleID := sarifRuleID(f)
+		if !seenRules[ruleID] {
+			seenRules[ruleID] = true
+			driver.Rules = append(driver.Rules, sarifRule{
+				ID:               ruleID,
+				ShortDescription: sarifText{Text: sarifRuleDescription(f)},
+			})
+		}
+		results = append(results, sarifResult{
+			RuleID:  ruleID,
+			Level:   sarifLevel(f),
+			Message: sarifText{Text: sarifMessage(f)},
+			Locations: []sarifLocation{
+				{PhysicalLocation: sarifPhysicalLocation{ArtifactLocation: sarifArtifactLocation{URI: f.URL}}},
+			},
+		})
+	}
+
+	log := sarifLog{
+		Version: "2.1.0",
+		Schema:  sarifSchemaURI,
+		Runs: []sarifRun{
+			{Tool: sarifTool{Driver: driver}, Results: results},
+		},
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(log)
+}
+
+// sarifRuleID gives StatusError findings a fixed rule, since they carry no
+// Header to key off of — the scan itself failed before any header check ran.
+func sarifRuleID(f Finding) string {
+	if f.Status == StatusError {
+		return "scan-error"
+	}
+	return f.Header
+}
+
+func sarifRuleDescription(f Finding) string {
+	if f.Status == StatusError {
+		return "The scan could not complete for this target."
+	}
+	return fmt.Sprintf("Checks the %s response header.", f.Header)
+}
+
+// sarifMessage builds a self-contained message: a Missing/Weak finding's
+// Message field is often empty (see Finding.Message), so the status and
+// header are spelled out here rather than assuming the caller already knows
+// what triggered the result.
+func sarifMessage(f Finding) string {
+	if f.Status == StatusError {
+		return f.Message
+	}
+	msg := fmt.Sprintf("%s header is %s", f.Header, f.Status)
+	if f.Message != "" {
+		msg += ": " + f.Message
+	}
+	return msg
+}
+
+// sarifLevel maps Severity to a SARIF result level; a StatusError finding has
+// no Severity of its own (the scan never got far enough to check headers) so
+// it always reports as "error" — a failed scan is not merely a warning.
+func sarifLevel(f Finding) string {
+	if f.Status == StatusError {
+		return "error"
+	}
+	switch f.Severity {
+	case SeverityLow:
+		return "note"
+	case SeverityHigh:
+		return "error"
+	default:
+		return "warning"
+	}
+}

--- a/internal/scanner/sarif.go
+++ b/internal/scanner/sarif.go
@@ -8,7 +8,7 @@ import (
 
 // sarifSchemaURI pins the exact SARIF 2.1.0 schema document these reports
 // validate against, per oasis-tcs/sarif-spec.
-const sarifSchemaURI = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/Schemata/sarif-schema-2.1.0.json"
+const sarifSchemaURI = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json"
 
 type sarifLog struct {
 	Version string     `json:"version"`
@@ -77,22 +77,12 @@ func (SarifReporter) Report(findings []Finding, w io.Writer) error {
 		if f.Status == StatusPass {
 			continue
 		}
-		ruleID := sarifRuleID(f)
-		if !seenRules[ruleID] {
-			seenRules[ruleID] = true
-			driver.Rules = append(driver.Rules, sarifRule{
-				ID:               ruleID,
-				ShortDescription: sarifText{Text: sarifRuleDescription(f)},
-			})
+		rule, result := sarifRuleAndResult(f)
+		if !seenRules[rule.ID] {
+			seenRules[rule.ID] = true
+			driver.Rules = append(driver.Rules, rule)
 		}
-		results = append(results, sarifResult{
-			RuleID:  ruleID,
-			Level:   sarifLevel(f),
-			Message: sarifText{Text: sarifMessage(f)},
-			Locations: []sarifLocation{
-				{PhysicalLocation: sarifPhysicalLocation{ArtifactLocation: sarifArtifactLocation{URI: f.URL}}},
-			},
-		})
+		results = append(results, result)
 	}
 
 	log := sarifLog{
@@ -108,45 +98,44 @@ func (SarifReporter) Report(findings []Finding, w io.Writer) error {
 	return enc.Encode(log)
 }
 
-// sarifRuleID gives StatusError findings a fixed rule, since they carry no
-// Header to key off of — the scan itself failed before any header check ran.
-func sarifRuleID(f Finding) string {
+// sarifRuleAndResult builds the rule and result for a single non-pass
+// finding. StatusError findings carry no Header/Severity of their own — the
+// scan never got far enough to check headers — so they're branched on once
+// here rather than in each field separately: a fixed "scan-error" rule, and
+// a level of "error" since a failed scan is not merely a warning.
+func sarifRuleAndResult(f Finding) (sarifRule, sarifResult) {
+	var ruleID, description, message, level string
 	if f.Status == StatusError {
-		return "scan-error"
+		ruleID = "scan-error"
+		description = "The scan could not complete for this target."
+		message = f.Message
+		level = "error"
+	} else {
+		ruleID = f.Header
+		description = fmt.Sprintf("Checks the %s response header.", f.Header)
+		message = fmt.Sprintf("%s header is %s", f.Header, f.Status)
+		if f.Message != "" {
+			message += ": " + f.Message
+		}
+		level = sarifLevel(f.Severity)
 	}
-	return f.Header
+
+	rule := sarifRule{ID: ruleID, ShortDescription: sarifText{Text: description}}
+	result := sarifResult{
+		RuleID:  ruleID,
+		Level:   level,
+		Message: sarifText{Text: message},
+		Locations: []sarifLocation{
+			{PhysicalLocation: sarifPhysicalLocation{ArtifactLocation: sarifArtifactLocation{URI: f.URL}}},
+		},
+	}
+	return rule, result
 }
 
-func sarifRuleDescription(f Finding) string {
-	if f.Status == StatusError {
-		return "The scan could not complete for this target."
-	}
-	return fmt.Sprintf("Checks the %s response header.", f.Header)
-}
-
-// sarifMessage builds a self-contained message: a Missing/Weak finding's
-// Message field is often empty (see Finding.Message), so the status and
-// header are spelled out here rather than assuming the caller already knows
-// what triggered the result.
-func sarifMessage(f Finding) string {
-	if f.Status == StatusError {
-		return f.Message
-	}
-	msg := fmt.Sprintf("%s header is %s", f.Header, f.Status)
-	if f.Message != "" {
-		msg += ": " + f.Message
-	}
-	return msg
-}
-
-// sarifLevel maps Severity to a SARIF result level; a StatusError finding has
-// no Severity of its own (the scan never got far enough to check headers) so
-// it always reports as "error" — a failed scan is not merely a warning.
-func sarifLevel(f Finding) string {
-	if f.Status == StatusError {
-		return "error"
-	}
-	switch f.Severity {
+// sarifLevel maps Severity to a SARIF result level, per the low->note,
+// medium->warning, high->error scheme.
+func sarifLevel(s Severity) string {
+	switch s {
 	case SeverityLow:
 		return "note"
 	case SeverityHigh:

--- a/internal/scanner/sarif_test.go
+++ b/internal/scanner/sarif_test.go
@@ -1,0 +1,167 @@
+package scanner_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/PhyberApex/mamori/internal/scanner"
+)
+
+func TestSarifReporterOmitsPassFindings(t *testing.T) {
+	findings := []scanner.Finding{
+		{
+			URL:      "https://a.example",
+			Header:   "Strict-Transport-Security",
+			Status:   scanner.StatusPass,
+			Severity: scanner.SeverityHigh,
+		},
+		{
+			URL:       "https://a.example",
+			Header:    "X-Frame-Options",
+			Status:    scanner.StatusMissing,
+			Severity:  scanner.SeverityMedium,
+			Reference: "https://owasp.example/xfo",
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := (scanner.SarifReporter{}).Report(findings, &buf); err != nil {
+		t.Fatalf("Report() returned error: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, buf.String())
+	}
+
+	if doc["version"] != "2.1.0" {
+		t.Errorf("version = %v, want %q", doc["version"], "2.1.0")
+	}
+
+	runs, ok := doc["runs"].([]any)
+	if !ok || len(runs) != 1 {
+		t.Fatalf("runs = %v, want a single run", doc["runs"])
+	}
+	run := runs[0].(map[string]any)
+
+	results, ok := run["results"].([]any)
+	if !ok {
+		t.Fatalf("results is not an array: %v", run["results"])
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1 (pass finding should be omitted)", len(results))
+	}
+
+	result := results[0].(map[string]any)
+	if result["ruleId"] != "X-Frame-Options" {
+		t.Errorf("ruleId = %v, want %q", result["ruleId"], "X-Frame-Options")
+	}
+}
+
+func TestSarifReporterMapsSeverityToLevel(t *testing.T) {
+	findings := []scanner.Finding{
+		{URL: "https://a.example", Header: "Referrer-Policy", Status: scanner.StatusMissing, Severity: scanner.SeverityLow},
+		{URL: "https://a.example", Header: "Permissions-Policy", Status: scanner.StatusMissing, Severity: scanner.SeverityMedium},
+		{URL: "https://a.example", Header: "Content-Security-Policy", Status: scanner.StatusMissing, Severity: scanner.SeverityHigh},
+		{URL: "https://down.example", Status: scanner.StatusError, Message: "context deadline exceeded"},
+	}
+
+	var buf bytes.Buffer
+	if err := (scanner.SarifReporter{}).Report(findings, &buf); err != nil {
+		t.Fatalf("Report() returned error: %v", err)
+	}
+
+	var doc struct {
+		Runs []struct {
+			Results []struct {
+				RuleID  string `json:"ruleId"`
+				Level   string `json:"level"`
+				Message struct {
+					Text string `json:"text"`
+				} `json:"message"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, buf.String())
+	}
+
+	levels := map[string]string{}
+	for _, r := range doc.Runs[0].Results {
+		levels[r.RuleID] = r.Level
+	}
+
+	want := map[string]string{
+		"Referrer-Policy":         "note",
+		"Permissions-Policy":      "warning",
+		"Content-Security-Policy": "error",
+		"scan-error":              "error",
+	}
+	for ruleID, wantLevel := range want {
+		if levels[ruleID] != wantLevel {
+			t.Errorf("level for %q = %q, want %q", ruleID, levels[ruleID], wantLevel)
+		}
+	}
+
+	for _, r := range doc.Runs[0].Results {
+		if r.RuleID == "scan-error" && r.Message.Text != "context deadline exceeded" {
+			t.Errorf("scan-error message = %q, want the scan error text", r.Message.Text)
+		}
+	}
+}
+
+func TestSarifReporterEnvelopeAndLocation(t *testing.T) {
+	findings := []scanner.Finding{
+		{URL: "https://a.example", Header: "X-Frame-Options", Status: scanner.StatusMissing, Severity: scanner.SeverityMedium},
+	}
+
+	var buf bytes.Buffer
+	if err := (scanner.SarifReporter{}).Report(findings, &buf); err != nil {
+		t.Fatalf("Report() returned error: %v", err)
+	}
+
+	var doc struct {
+		Version string `json:"version"`
+		Schema  string `json:"$schema"`
+		Runs    []struct {
+			Tool struct {
+				Driver struct {
+					Name  string `json:"name"`
+					Rules []struct {
+						ID string `json:"id"`
+					} `json:"rules"`
+				} `json:"driver"`
+			} `json:"tool"`
+			Results []struct {
+				Locations []struct {
+					PhysicalLocation struct {
+						ArtifactLocation struct {
+							URI string `json:"uri"`
+						} `json:"artifactLocation"`
+					} `json:"physicalLocation"`
+				} `json:"locations"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, buf.String())
+	}
+
+	if doc.Version != "2.1.0" {
+		t.Errorf("version = %q, want %q", doc.Version, "2.1.0")
+	}
+	if doc.Schema == "" {
+		t.Error("$schema is empty, want the SARIF 2.1.0 schema URI")
+	}
+	if doc.Runs[0].Tool.Driver.Name != "mamori" {
+		t.Errorf("tool.driver.name = %q, want %q", doc.Runs[0].Tool.Driver.Name, "mamori")
+	}
+	if len(doc.Runs[0].Tool.Driver.Rules) != 1 || doc.Runs[0].Tool.Driver.Rules[0].ID != "X-Frame-Options" {
+		t.Errorf("tool.driver.rules = %+v, want a single X-Frame-Options rule", doc.Runs[0].Tool.Driver.Rules)
+	}
+	loc := doc.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI
+	if loc != "https://a.example" {
+		t.Errorf("result location URI = %q, want %q", loc, "https://a.example")
+	}
+}


### PR DESCRIPTION
## What/why

Adds a `SarifReporter` implementing the existing `Reporter` interface, so `mamori` can emit `-o sarif` output alongside `terminal`/`json` — for GitHub code scanning / CI integration.

- `Severity` maps to SARIF `level`: low→`note`, medium→`warning`, high→`error`.
- Only non-pass findings (`missing`, `weak`, `error`) become SARIF results — a clean header carries no actionable location.
- `StatusError` findings (the scan itself failed) get a fixed `scan-error` rule and always report as `error`, since they carry no `Header`/`Severity` of their own.
- Follows the SARIF 2.1.0 schema (oasis-tcs/sarif-spec): top-level `version`/`$schema`/`runs`, `runs[].tool.driver`, `runs[].results[].message`/`locations`, etc.
- Wired `sarif` through `config.Output`, `-o`/`MAMORI_OUTPUT`, and `cmd/mamori/main.go`'s `reporterFor`, matching how `json` was added.

## Test evidence

- New unit tests for `SarifReporter` (pass-finding omission, severity→level mapping including the `StatusError` case, and the SARIF envelope/rule/location structure).
- New `config` test for `-o sarif` and a `cmd/mamori` end-to-end test asserting `run()` with `-o sarif` produces valid SARIF JSON with results.
- `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...`, and `go test ./...` all pass clean.
- Ran `/code-review` against `origin/main`; fixed the two findings it surfaced (a dead `$schema` URL path, and four helper functions each re-branching on `StatusError` — collapsed into one per-finding builder).

Closes #55

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*