### PR TITLE
feat(scanner): add HSTS preload-eligibility checker

### DIFF
--- a/cmd/mamori/main_test.go
+++ b/cmd/mamori/main_test.go
@@ -15,7 +15,7 @@ import (
 // server built from this map alone never trips -fail-on at any severity.
 func strongHeaders() map[string]string {
 	return map[string]string{
-		"Strict-Transport-Security": "max-age=63072000; includeSubDomains",
+		"Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
 		"X-Content-Type-Options":    "nosniff",
 		"X-Frame-Options":           "DENY",
 		"Content-Security-Policy":   "default-src 'self'",

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -83,24 +83,9 @@ func (HSTSPreloadChecker) Check(headers http.Header) []Finding {
 	if base := (HSTSChecker{}).Check(headers); base[0].Status != StatusPass {
 		return nil
 	}
-	finding := Finding{
-		Header:    hstsPreloadHeaderLabel,
-		Status:    StatusPass,
-		Severity:  SeverityLow,
-		Reference: "https://hstspreload.org/",
-	}
-	for _, value := range headers.Values("Strict-Transport-Security") {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
-		if weak, message := hstsPreloadWeakness(value); weak {
-			finding.Status = StatusWeak
-			finding.Message = message
-			break
-		}
-	}
-	return []Finding{finding}
+	findings := checkValue(headers, "Strict-Transport-Security", SeverityLow, "https://hstspreload.org/", hstsPreloadWeakness)
+	findings[0].Header = hstsPreloadHeaderLabel
+	return findings
 }
 
 // hstsPreloadWeakness flags an HSTS value missing includeSubDomains or

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -81,7 +81,8 @@ const hstsPreloadHeaderLabel = "Strict-Transport-Security (preload)"
 type HSTSPreloadChecker struct{}
 
 func (HSTSPreloadChecker) Check(headers http.Header) []Finding {
-	if base := (HSTSChecker{}).Check(headers); base[0].Status != StatusPass {
+	hstsFindings := (HSTSChecker{}).Check(headers)
+	if hstsFindings[0].Status != StatusPass {
 		return nil
 	}
 	findings := checkValue(headers, "Strict-Transport-Security", SeverityLow, "https://hstspreload.org/", hstsPreloadWeakness)

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -14,6 +14,7 @@ type Checker interface {
 func DefaultCheckers() []Checker {
 	return []Checker{
 		HSTSChecker{},
+		HSTSPreloadChecker{},
 		ContentTypeOptionsChecker{},
 		FrameOptionsChecker{},
 		CSPChecker{},
@@ -64,6 +65,68 @@ func hstsWeakness(value string) (weak bool, message string) {
 		return false, ""
 	}
 	return true, "max-age directive is missing"
+}
+
+const hstsPreloadHeaderLabel = "Strict-Transport-Security (preload)"
+
+// HSTSPreloadChecker evaluates eligibility for browsers' HSTS preload lists,
+// which requires includeSubDomains and preload directives on top of the
+// valid, positive max-age HSTSChecker already demands. It only evaluates
+// targets where HSTSChecker passes: a missing or self-defeating max-age is
+// HSTSChecker's finding to make, not this one's, and re-flagging the same
+// root cause under a second header would just be noise. It reports under a
+// distinct Header label so the two findings never collide when both are
+// present for the same response.
+type HSTSPreloadChecker struct{}
+
+func (HSTSPreloadChecker) Check(headers http.Header) []Finding {
+	if base := (HSTSChecker{}).Check(headers); base[0].Status != StatusPass {
+		return nil
+	}
+	finding := Finding{
+		Header:    hstsPreloadHeaderLabel,
+		Status:    StatusPass,
+		Severity:  SeverityLow,
+		Reference: "https://hstspreload.org/",
+	}
+	for _, value := range headers.Values("Strict-Transport-Security") {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if weak, message := hstsPreloadWeakness(value); weak {
+			finding.Status = StatusWeak
+			finding.Message = message
+			break
+		}
+	}
+	return []Finding{finding}
+}
+
+// hstsPreloadWeakness flags an HSTS value missing includeSubDomains or
+// preload: both are required for a domain to be accepted onto browsers'
+// built-in HSTS preload lists, even though the header is otherwise fully
+// functional per hstsWeakness.
+func hstsPreloadWeakness(value string) (weak bool, message string) {
+	hasIncludeSubDomains := false
+	hasPreload := false
+	for _, directive := range strings.Split(value, ";") {
+		switch strings.ToLower(strings.TrimSpace(directive)) {
+		case "includesubdomains":
+			hasIncludeSubDomains = true
+		case "preload":
+			hasPreload = true
+		}
+	}
+	switch {
+	case !hasIncludeSubDomains && !hasPreload:
+		return true, "missing both includeSubDomains and preload directives, so it is not eligible for HSTS preload lists"
+	case !hasIncludeSubDomains:
+		return true, "missing the includeSubDomains directive, so it is not eligible for HSTS preload lists"
+	case !hasPreload:
+		return true, "missing the preload directive, so it is not eligible for HSTS preload lists"
+	}
+	return false, ""
 }
 
 type ContentTypeOptionsChecker struct{}

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -140,6 +140,88 @@ func TestCheckValueIgnoresBlankDuplicateOccurrence(t *testing.T) {
 	}
 }
 
+func TestHSTSPreloadSkipsWhenBaseHSTSDoesNotPass(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers http.Header
+	}{
+		{"missing header", http.Header{}},
+		{"zero max-age", http.Header{"Strict-Transport-Security": {"max-age=0; includeSubDomains; preload"}}},
+		{"unparseable max-age", http.Header{"Strict-Transport-Security": {"max-age=notanumber; includeSubDomains; preload"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.HSTSPreloadChecker{}.Check(tt.headers)
+			if len(findings) != 0 {
+				t.Errorf("Check() returned %d findings, want 0 (HSTSChecker doesn't pass): %+v", len(findings), findings)
+			}
+		})
+	}
+}
+
+func TestHSTSPreloadFlagsMissingDirectives(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"missing both directives", "max-age=63072000"},
+		{"missing preload", "max-age=63072000; includeSubDomains"},
+		{"missing includeSubDomains", "max-age=63072000; preload"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.HSTSPreloadChecker{}.Check(http.Header{"Strict-Transport-Security": {tt.value}})
+			if len(findings) != 1 {
+				t.Fatalf("Check() returned %d findings, want 1: %+v", len(findings), findings)
+			}
+			if findings[0].Header != "Strict-Transport-Security (preload)" {
+				t.Errorf("Header = %q, want %q", findings[0].Header, "Strict-Transport-Security (preload)")
+			}
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
+			}
+			if findings[0].Reference == "" {
+				t.Error("Reference is empty, want a docs URL")
+			}
+		})
+	}
+}
+
+func TestHSTSPreloadAcceptsBothDirectives(t *testing.T) {
+	findings := scanner.HSTSPreloadChecker{}.Check(http.Header{
+		"Strict-Transport-Security": {"max-age=63072000; includeSubDomains; preload"},
+	})
+	if len(findings) != 1 {
+		t.Fatalf("Check() returned %d findings, want 1: %+v", len(findings), findings)
+	}
+	if findings[0].Status != scanner.StatusPass {
+		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
+	}
+}
+
+func TestHSTSPreloadHeaderLabelDoesNotCollideWithHSTS(t *testing.T) {
+	headers := http.Header{"Strict-Transport-Security": {"max-age=63072000"}}
+	hsts := scanner.HSTSChecker{}.Check(headers)
+	preload := scanner.HSTSPreloadChecker{}.Check(headers)
+	if hsts[0].Header == preload[0].Header {
+		t.Errorf("HSTS and preload findings share Header %q, want distinct labels", hsts[0].Header)
+	}
+}
+
+func TestHSTSPreloadFlagsWeakAmongDuplicateHeaders(t *testing.T) {
+	headers := http.Header{"Strict-Transport-Security": {
+		"max-age=63072000; includeSubDomains; preload",
+		"max-age=63072000",
+	}}
+	findings := scanner.HSTSPreloadChecker{}.Check(headers)
+	if findings[0].Status != scanner.StatusWeak {
+		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+	}
+}
+
 func TestContentTypeOptionsWeakValues(t *testing.T) {
 	tests := []string{"garbage", "sniff"}
 	for _, value := range tests {

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var allSecurityHeaders = map[string]string{
-	"Strict-Transport-Security": "max-age=63072000",
+	"Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
 	"X-Content-Type-Options":    "nosniff",
 	"X-Frame-Options":           "DENY",
 	"Content-Security-Policy":   "default-src 'self'",
@@ -20,14 +20,14 @@ var allSecurityHeaders = map[string]string{
 	"Permissions-Policy":        "geolocation=()",
 }
 
-func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
+func scanOne(t *testing.T, handler http.Handler, want int) []scanner.Finding {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
 	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, []string{srv.URL}, 1)
-	if len(findings) != 6 {
-		t.Fatalf("Scan() returned %d findings, want 6", len(findings))
+	if len(findings) != want {
+		t.Fatalf("Scan() returned %d findings, want %d", len(findings), want)
 	}
 	for _, f := range findings {
 		if f.URL != srv.URL {
@@ -51,12 +51,12 @@ func TestScanAllHeadersPresent(t *testing.T) {
 		for name, value := range allSecurityHeaders {
 			w.Header().Set(name, value)
 		}
-	}))
+	}), 7)
 	assertAllStatus(t, findings, scanner.StatusPass)
 }
 
 func TestScanAllHeadersMissing(t *testing.T) {
-	findings := scanOne(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	findings := scanOne(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}), 6)
 	assertAllStatus(t, findings, scanner.StatusMissing)
 }
 
@@ -69,7 +69,7 @@ func TestScanFallsBackToGETWhenHEADRejected(t *testing.T) {
 		for name, value := range allSecurityHeaders {
 			w.Header().Set(name, value)
 		}
-	}))
+	}), 7)
 	assertAllStatus(t, findings, scanner.StatusPass)
 }
 

--- a/site/checks/hsts-preload.md
+++ b/site/checks/hsts-preload.md
@@ -1,0 +1,30 @@
+---
+layout: page
+title: Strict-Transport-Security (preload)
+permalink: /checks/hsts-preload
+---
+
+**Severity:** low
+
+## What it does
+
+Checks whether a functional `Strict-Transport-Security` header is also eligible for browsers' built-in HSTS preload lists, which enforce HTTPS on a domain from a user's very first connection — before it has ever sent that domain an HSTS header at all.
+
+## Expected value
+
+```
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+```
+
+- `includeSubDomains` — applies the policy to all subdomains too.
+- `preload` — signals opt-in submission to the [HSTS preload list](https://hstspreload.org/).
+
+## What mamori checks
+
+This check only runs once the [`Strict-Transport-Security`](strict-transport-security) check already passes (a valid, positive `max-age`) — a missing or self-defeating header is that check's finding to make, not this one's. Given a passing header, a value missing `includeSubDomains` or `preload` is reported as a low-severity `WEAK` finding under a distinct `Strict-Transport-Security (preload)` label, so it doesn't collide with the base HSTS finding in the same report.
+
+## Further reading
+
+- [hstspreload.org](https://hstspreload.org/)
+- [MDN: Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
+- [OWASP: HTTP Strict Transport Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html)

--- a/site/checks/strict-transport-security.md
+++ b/site/checks/strict-transport-security.md
@@ -23,6 +23,8 @@ Strict-Transport-Security: max-age=63072000; includeSubDomains
 
 Presence of the header, and that `max-age` actually enforces HTTPS. A missing or empty header is reported as a high-severity finding. A present header with a missing, unparseable, or non-positive `max-age` (e.g. `max-age=0`) is reported as `WEAK` — it disables HSTS just as effectively as not sending the header at all.
 
+See also the separate [HSTS preload eligibility check](hsts-preload), which only runs once this one passes.
+
 ## Further reading
 
 - [MDN: Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)

--- a/site/index.md
+++ b/site/index.md
@@ -10,6 +10,7 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | Header | Severity | Reference |
 |---|---|---|
 | `Strict-Transport-Security` | high | [docs](checks/strict-transport-security) |
+| `Strict-Transport-Security` (preload) | low | [docs](checks/hsts-preload) |
 | `X-Content-Type-Options` | medium | [docs](checks/x-content-type-options) |
 | `X-Frame-Options` | medium | [docs](checks/x-frame-options) |
 | `Content-Security-Policy` | high | [docs](checks/content-security-policy) |


### PR DESCRIPTION
## What/why

Adds `HSTSPreloadChecker`, which flags `Strict-Transport-Security` values that are functional (per `HSTSChecker`) but not eligible for browsers' HSTS preload lists — i.e. missing the `includeSubDomains` or `preload` directives.

- Only evaluates targets where `HSTSChecker` already passes (valid, positive `max-age`); a missing/self-defeating header is `HSTSChecker`'s finding to make.
- Reports `StatusWeak` when `includeSubDomains` or `preload` is absent, with a message naming which directive(s) are missing.
- Uses a distinct `Strict-Transport-Security (preload)` `Header` label so it doesn't collide with the base HSTS finding.
- Registered in `DefaultCheckers()`, documented at `site/checks/hsts-preload.md`, cross-linked from `site/checks/strict-transport-security.md` and listed in `site/index.md`.

## Test evidence

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass, including new checker tests covering: skip when base HSTS fails (missing header, zero max-age, unparseable max-age), flagging each missing-directive combination, passing when both directives present, non-collision of Header labels with the base HSTS finding, and correct handling of duplicate headers.
- Updated `cmd/mamori/main_test.go` and `internal/scanner/scan_test.go` fixtures/finding counts to account for the new checker.

Closes #49

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*