### PR TITLE
feat(scanner): add mixed-content checker for https targets

### DIFF
--- a/internal/scanner/mixedcontent.go
+++ b/internal/scanner/mixedcontent.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"bytes"
 	"fmt"
 	"net/url"
 	"strings"
@@ -58,25 +57,9 @@ func (MixedContentChecker) CheckBody(body []byte, targetURL string) []Finding {
 	if err != nil || base.Scheme != "https" {
 		return nil
 	}
-	doc, err := html.Parse(bytes.NewReader(body))
-	if err != nil {
-		return nil
-	}
-
-	var findings []Finding
-	var walk func(*html.Node)
-	walk = func(n *html.Node) {
-		if n.Type == html.ElementNode {
-			if f := mixedContentFinding(n, base); f != nil {
-				findings = append(findings, *f)
-			}
-		}
-		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			walk(c)
-		}
-	}
-	walk(doc)
-	return findings
+	return walkElements(body, func(n *html.Node) *Finding {
+		return mixedContentFinding(n, base)
+	})
 }
 
 // mixedContentFinding judges a single element, returning nil for anything

--- a/internal/scanner/mixedcontent.go
+++ b/internal/scanner/mixedcontent.go
@@ -1,0 +1,122 @@
+package scanner
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+const mixedContentReference = "https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content"
+
+// mixedContentAttrs maps each in-scope element to the attribute holding its
+// resource reference. link is excluded here and handled separately, since
+// only some of its rel values are actually fetched by the browser (see
+// mixedContentLinkRels).
+var mixedContentAttrs = map[string]string{
+	"img":    "src",
+	"script": "src",
+	"iframe": "src",
+	"audio":  "src",
+	"video":  "src",
+	"link":   "href",
+}
+
+// mixedContentLinkRels lists the rel values that make a <link> a subresource
+// the browser actually fetches, and so applies mixed-content blocking to.
+// Most rel values (canonical, alternate, author, license, search, ...) are
+// pure metadata the browser never dereferences, so treating every <link
+// href> as mixed content would flag the canonical tag on most real https://
+// pages.
+var mixedContentLinkRels = []string{
+	"stylesheet",
+	"icon",
+	"apple-touch-icon",
+	"apple-touch-icon-precomposed",
+	"manifest",
+	"preload",
+	"prefetch",
+	"prerender",
+}
+
+// MixedContentChecker flags resources an https:// page loads over plain
+// http:// instead. Those resources bypass TLS entirely, so a network
+// attacker can tamper with or substitute them even though the page itself
+// was served securely — the padlock in the address bar doesn't cover them.
+//
+// There's no StatusPass case here: a clean page has nothing to flag, so it
+// produces no findings at all, mirroring how BannerDisclosureChecker treats
+// absence as the desired state. The check only applies to https:// targets —
+// an http:// target has no TLS guarantee for mixed content to undermine in
+// the first place.
+type MixedContentChecker struct{}
+
+func (MixedContentChecker) CheckBody(body []byte, targetURL string) []Finding {
+	base, err := url.Parse(targetURL)
+	if err != nil || base.Scheme != "https" {
+		return nil
+	}
+	doc, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return nil
+	}
+
+	var findings []Finding
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			if f := mixedContentFinding(n, base); f != nil {
+				findings = append(findings, *f)
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+	return findings
+}
+
+// mixedContentFinding judges a single element, returning nil for anything
+// that isn't an in-scope tag, has no resource reference, or resolves to a
+// scheme other than http (relative and protocol-relative references inherit
+// the page's own https scheme, so they resolve safe).
+func mixedContentFinding(n *html.Node, base *url.URL) *Finding {
+	attrName, ok := mixedContentAttrs[n.Data]
+	if !ok {
+		return nil
+	}
+	if n.Data == "link" && !hasAnyRelValue(n, mixedContentLinkRels) {
+		return nil
+	}
+
+	ref, ok := attrValue(n, attrName)
+	if !ok || strings.TrimSpace(ref) == "" {
+		return nil
+	}
+	resolved, err := base.Parse(ref)
+	if err != nil || !strings.EqualFold(resolved.Scheme, "http") {
+		return nil
+	}
+
+	return &Finding{
+		Header:    fmt.Sprintf("<%s %s=%q>", n.Data, attrName, ref),
+		Status:    StatusWeak,
+		Severity:  SeverityMedium,
+		Reference: mixedContentReference,
+		Message:   fmt.Sprintf("%s=%q loads over insecure http://, bypassing the page's TLS protection", attrName, ref),
+	}
+}
+
+// hasAnyRelValue reports whether n's rel attribute contains any of want, per
+// hasRelValue's space-separated-token-list handling.
+func hasAnyRelValue(n *html.Node, want []string) bool {
+	for _, w := range want {
+		if hasRelValue(n, w) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scanner/mixedcontent_test.go
+++ b/internal/scanner/mixedcontent_test.go
@@ -100,13 +100,10 @@ func TestMixedContentCheckerReportsEachOffendingTagIndependently(t *testing.T) {
 func TestRunAllBodyIncludesMixedContentByDefault(t *testing.T) {
 	body := []byte(`<img src="http://insecure.example.net/logo.png">`)
 	findings := scanner.RunAllBody(scanner.DefaultBodyCheckers(), body, mixedContentTargetURL)
-	found := false
-	for _, f := range findings {
-		if f.Severity == scanner.SeverityMedium {
-			found = true
-		}
+	if len(findings) != 1 {
+		t.Fatalf("RunAllBody() returned %d findings, want 1", len(findings))
 	}
-	if !found {
-		t.Errorf("RunAllBody(DefaultBodyCheckers()) = %+v, want a Mixed Content finding", findings)
+	if findings[0].Severity != scanner.SeverityMedium {
+		t.Errorf("Severity = %q, want %q", findings[0].Severity, scanner.SeverityMedium)
 	}
 }

--- a/internal/scanner/mixedcontent_test.go
+++ b/internal/scanner/mixedcontent_test.go
@@ -1,0 +1,112 @@
+package scanner_test
+
+import (
+	"testing"
+
+	"github.com/PhyberApex/mamori/internal/scanner"
+)
+
+const mixedContentTargetURL = "https://example.com/"
+
+func TestMixedContentCheckerFlagsInsecureReferences(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+	}{
+		{"img src", `<img src="http://insecure.example.net/logo.png">`},
+		{"script src", `<script src="http://insecure.example.net/app.js"></script>`},
+		{"link stylesheet href", `<link rel="stylesheet" href="http://insecure.example.net/app.css">`},
+		{"link icon href", `<link rel="icon" href="http://insecure.example.net/favicon.ico">`},
+		{"iframe src", `<iframe src="http://insecure.example.net/embed"></iframe>`},
+		{"audio src", `<audio src="http://insecure.example.net/a.mp3"></audio>`},
+		{"video src", `<video src="http://insecure.example.net/v.mp4"></video>`},
+		{"uppercase scheme", `<img src="HTTP://insecure.example.net/logo.png">`},
+		{"link with multiple rel tokens", `<link rel="preload stylesheet" href="http://insecure.example.net/app.css">`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.MixedContentChecker{}.CheckBody([]byte(tt.html), mixedContentTargetURL)
+			if len(findings) != 1 {
+				t.Fatalf("CheckBody() returned %d findings, want 1: %+v", len(findings), findings)
+			}
+			f := findings[0]
+			if f.Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", f.Status, scanner.StatusWeak)
+			}
+			if f.Severity != scanner.SeverityMedium {
+				t.Errorf("Severity = %q, want %q", f.Severity, scanner.SeverityMedium)
+			}
+			if f.Reference == "" {
+				t.Error("Reference is empty, want a docs URL")
+			}
+			if f.Message == "" {
+				t.Error("Message is empty")
+			}
+		})
+	}
+}
+
+func TestMixedContentCheckerIgnoresSafeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+	}{
+		{"https src", `<img src="https://secure.example.net/logo.png">`},
+		{"protocol-relative src", `<img src="//secure.example.net/logo.png">`},
+		{"relative src", `<script src="/app.js"></script>`},
+		{"non-fetching link rel", `<link rel="canonical" href="http://insecure.example.net/page">`},
+		{"tag with no src/href", `<script>console.log("inline")</script>`},
+		{"no in-scope tags", `<html><body><p>hello</p></body></html>`},
+		{"empty body", ``},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.MixedContentChecker{}.CheckBody([]byte(tt.html), mixedContentTargetURL)
+			if len(findings) != 0 {
+				t.Fatalf("CheckBody() returned %d findings, want 0: %+v", len(findings), findings)
+			}
+		})
+	}
+}
+
+func TestMixedContentCheckerSkipsNonHTTPSTarget(t *testing.T) {
+	findings := scanner.MixedContentChecker{}.CheckBody([]byte(`<img src="http://insecure.example.net/logo.png">`), "http://example.com/")
+	if findings != nil {
+		t.Fatalf("CheckBody() on an http:// target = %+v, want nil (mixed content only applies to https:// pages)", findings)
+	}
+}
+
+func TestMixedContentCheckerHandlesUnparseableTargetURL(t *testing.T) {
+	findings := scanner.MixedContentChecker{}.CheckBody([]byte(`<img src="http://insecure.example.net/logo.png">`), "://not-a-url")
+	if findings != nil {
+		t.Fatalf("CheckBody() with an unparseable target URL = %+v, want nil", findings)
+	}
+}
+
+func TestMixedContentCheckerReportsEachOffendingTagIndependently(t *testing.T) {
+	body := `
+		<img src="http://insecure.example.net/a.png">
+		<img src="https://secure.example.net/b.png">
+		<script src="http://insecure.example.net/c.js"></script>
+	`
+	findings := scanner.MixedContentChecker{}.CheckBody([]byte(body), mixedContentTargetURL)
+	if len(findings) != 2 {
+		t.Fatalf("CheckBody() returned %d findings, want 2: %+v", len(findings), findings)
+	}
+}
+
+func TestRunAllBodyIncludesMixedContentByDefault(t *testing.T) {
+	body := []byte(`<img src="http://insecure.example.net/logo.png">`)
+	findings := scanner.RunAllBody(scanner.DefaultBodyCheckers(), body, mixedContentTargetURL)
+	found := false
+	for _, f := range findings {
+		if f.Severity == scanner.SeverityMedium {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("RunAllBody(DefaultBodyCheckers()) = %+v, want a Mixed Content finding", findings)
+	}
+}

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -105,6 +105,25 @@ func TestScanRunsBodyCheckersWhenConfigured(t *testing.T) {
 	}
 }
 
+func TestScanFlagsMixedContentOnHTTPSTarget(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<img src="http://insecure.example.net/logo.png">`))
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.Scan(t.Context(), srv.Client(), nil, scanner.DefaultBodyCheckers(), []string{srv.URL}, 1)
+	if len(findings) != 1 {
+		t.Fatalf("Scan() returned %d findings, want 1: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Severity != scanner.SeverityMedium {
+		t.Errorf("Severity = %q, want %q", f.Severity, scanner.SeverityMedium)
+	}
+	if f.URL != srv.URL {
+		t.Errorf("URL = %q, want %q", f.URL, srv.URL)
+	}
+}
+
 func TestScanCombinesHeaderAndBodyCheckerFindings(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/internal/scanner/sri.go
+++ b/internal/scanner/sri.go
@@ -18,7 +18,7 @@ type BodyChecker interface {
 }
 
 func DefaultBodyCheckers() []BodyChecker {
-	return []BodyChecker{SRIChecker{}}
+	return []BodyChecker{SRIChecker{}, MixedContentChecker{}}
 }
 
 func RunAllBody(checkers []BodyChecker, body []byte, targetURL string) []Finding {

--- a/internal/scanner/sri.go
+++ b/internal/scanner/sri.go
@@ -29,6 +29,32 @@ func RunAllBody(checkers []BodyChecker, body []byte, targetURL string) []Finding
 	return findings
 }
 
+// walkElements parses body as HTML and calls judge on every element node,
+// collecting each non-nil Finding it returns. It's the shared traversal
+// every BodyChecker needs — parsing and walking the tree is identical across
+// checkers; only how a single element is judged differs.
+func walkElements(body []byte, judge func(*html.Node) *Finding) []Finding {
+	doc, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return nil
+	}
+
+	var findings []Finding
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			if f := judge(n); f != nil {
+				findings = append(findings, *f)
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+	return findings
+}
+
 const sriReference = "https://cheatsheetseries.owasp.org/cheatsheets/Subresource_Integrity_Cheat_Sheet.html"
 
 // SRIChecker flags <script src> and <link rel="stylesheet" href> tags that
@@ -45,25 +71,9 @@ func (SRIChecker) CheckBody(body []byte, targetURL string) []Finding {
 	if err != nil {
 		return nil
 	}
-	doc, err := html.Parse(bytes.NewReader(body))
-	if err != nil {
-		return nil
-	}
-
-	var findings []Finding
-	var walk func(*html.Node)
-	walk = func(n *html.Node) {
-		if n.Type == html.ElementNode {
-			if f := sriFinding(n, base); f != nil {
-				findings = append(findings, *f)
-			}
-		}
-		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			walk(c)
-		}
-	}
-	walk(doc)
-	return findings
+	return walkElements(body, func(n *html.Node) *Finding {
+		return sriFinding(n, base)
+	})
 }
 
 // sriFinding judges a single element, returning nil for anything that isn't

--- a/site/checks/mixed-content.md
+++ b/site/checks/mixed-content.md
@@ -1,0 +1,28 @@
+---
+layout: page
+title: Mixed Content
+permalink: /checks/mixed-content
+---
+
+**Severity:** medium
+
+## What it does
+
+For `https://` targets, checks the response body for resources — images, scripts, stylesheets, iframes, audio, and video — loaded over plain `http://` instead of `https://`. Those resources bypass TLS entirely, so a network attacker can tamper with or substitute them even though the page itself was served securely: the padlock in the address bar doesn't cover them.
+
+## Expected value
+
+Every resource an `https://` page loads should also use `https://`, or a scheme-relative URL that inherits the page's own scheme:
+
+```html
+<img src="https://example.com/logo.png">
+<img src="//example.com/logo.png">
+```
+
+## What mamori checks
+
+Fetches and parses the response body with Go's HTML parser, then inspects the `src`/`href` attribute of every `img`, `script`, `link`, `iframe`, `audio`, and `video` tag, for `https://` targets only — an `http://` target has no TLS guarantee for mixed content to undermine. For `link`, only `rel` values the browser actually fetches count (`stylesheet`, `icon`, `apple-touch-icon`, `apple-touch-icon-precomposed`, `manifest`, `preload`, `prefetch`, `prerender`) — metadata-only relations like `canonical` or `alternate` are never dereferenced, so flagging them would be a false positive. Each reference that resolves to `http://` is reported as a medium-severity `WEAK` finding; a page can produce multiple findings, one per insecure reference. A page with no insecure references produces no findings — there's no `PASS` case, mirroring how the banner disclosure check treats absence as the desired state.
+
+## Further reading
+
+- [MDN: Mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content)

--- a/site/index.md
+++ b/site/index.md
@@ -18,3 +18,4 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `Permissions-Policy` | medium | [docs](checks/permissions-policy) |
 | `Server` / `X-Powered-By` | low | [docs](checks/banner-disclosure) |
 | `<script>` / `<link>` (SRI) | low | [docs](checks/subresource-integrity) |
+| Mixed Content | medium | [docs](checks/mixed-content) |


### PR DESCRIPTION
## What / why

Adds `MixedContentChecker`, a `BodyChecker` that scans the HTML response body of an `https://` target for `img`/`script`/`link`/`iframe`/`audio`/`video` `src`/`href` references that resolve to plain `http://`. Those resources bypass TLS entirely — a network attacker can tamper with or substitute them even though the page itself was served securely.

Reuses the `BodyChecker`/`fetchBody` infrastructure the SRI checker (#68) already introduced, rather than reintroducing it. For `<link>`, only `rel` values the browser actually fetches (`stylesheet`, `icon`, `apple-touch-icon`, `apple-touch-icon-precomposed`, `manifest`, `preload`, `prefetch`, `prerender`) are in scope, to avoid flagging purely metadata relations like `rel="canonical"`.

A follow-up commit extracts the DOM-walk boilerplate `CheckBody` shared with `SRIChecker` into a `walkElements` helper, per the self-review below.

## Test evidence

- New unit tests in `internal/scanner/mixedcontent_test.go` cover: each in-scope tag, case-insensitive scheme, protocol-relative/relative URLs (safe), non-fetching `link rel` values (safe), unparseable target URL, http:// target skipped entirely, multiple findings per page.
- New integration test in `scan_test.go` (`TestScanFlagsMixedContentOnHTTPSTarget`) exercises the checker through `Scan` over a real TLS server.
- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` all clean.
- `go test ./... -race`: all packages pass.
- Ran `/mattpocock-skills:code-review` (Standards + Spec axes) against `origin/main`; no hard violations or missing/incorrect requirements. Applied its one judgement-call finding (duplicated DOM-walk logic) as a follow-up refactor commit.

Closes #50

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*