### PR TITLE
feat: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug Report
+description: Report a problem with mamori
+title: "bug: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command invocation
+      description: The exact `mamori` command that triggers the problem.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include any output.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - go install
+        - Docker
+        - binary release
+        - built from source
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: The release tag, image tag, or commit you're running (there's no `-version` flag yet, so check how you installed it).
+    validations:
+      required: true
+
+  - type: input
+    id: os-arch
+    attributes:
+      label: OS/architecture
+      placeholder: e.g. linux/amd64, darwin/arm64
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature Request
+description: Propose a new feature or enhancement for mamori
+title: "feat: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem/motivation
+      description: What problem are you trying to solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Description
+
+<!-- What does this PR change, and why? -->
+
+Closes #<!-- issue number, or N/A -->
+
+## Checklist
+
+- [ ] Tests pass locally (`go test -race ./...`)
+- [ ] Lint passes locally (`golangci-lint run`)
+- [ ] Commit messages follow Conventional Commits
+- [ ] Linked issue via `Closes #...` (or `N/A`)


### PR DESCRIPTION
## What

Adds a GitHub issue template chooser with two forms plus a pull request template:

- `.github/ISSUE_TEMPLATE/config.yml` — chooser config, blank issues stay enabled, no external contact links.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — collects description, exact `mamori` command (code block), expected/actual behavior, install method (dropdown: `go install`, `Docker`, `binary release`, `built from source`), version, and optional OS/architecture. Auto-labels `bug` + `needs-triage`.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — collects problem/motivation and proposed solution (required), alternatives and additional context (optional). Auto-labels `enhancement` + `needs-triage`.
- `.github/pull_request_template.md` — description field, `Closes #...` linker, and a checklist covering `go test -race`, `golangci-lint run`, Conventional Commits, and the linked issue.

## Why

There were no issue or PR templates, so bug reports often omitted reproduction details (mamori has no `-version` flag and three install paths, so there was no consistent way to state what a reporter is running), and PRs carried no reminder of the Conventional Commits convention that `release-please` depends on or the CI checks it must pass.

## Test evidence

- Verified `bug`, `enhancement`, and `needs-triage` labels already exist in the repo (`gh label list`), so the issue-form `labels:` keys will apply cleanly.
- Manually reviewed the YAML against GitHub's issue-form schema (`name`, `description`, `body` with `input`/`textarea`/`dropdown` elements, `required: true` where specified).
- No Go code changed; `go test -race ./...` and `golangci-lint run` are unaffected.

Closes #72

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*