### PR TITLE
feat(scanner): add Cross-Origin-Opener-Policy checker

### DIFF
--- a/cmd/mamori/main_test.go
+++ b/cmd/mamori/main_test.go
@@ -20,6 +20,7 @@ func strongHeaders() map[string]string {
 		"X-Frame-Options":              "DENY",
 		"Content-Security-Policy":      "default-src 'self'",
 		"Referrer-Policy":              "strict-origin-when-cross-origin",
+		"Cross-Origin-Opener-Policy":   "same-origin",
 		"Cross-Origin-Resource-Policy": "same-origin",
 		"Permissions-Policy":           "geolocation=()",
 	}

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -18,6 +18,7 @@ func DefaultCheckers() []Checker {
 		FrameOptionsChecker{},
 		CSPChecker{},
 		ReferrerPolicyChecker{},
+		COOPChecker{},
 		CORPChecker{},
 		CookieChecker{},
 		PermissionsPolicyChecker{},
@@ -228,6 +229,33 @@ func effectiveReferrerPolicy(value string) string {
 		}
 	}
 	return effective
+}
+
+type COOPChecker struct{}
+
+func (COOPChecker) Check(headers http.Header) []Finding {
+	return checkValue(
+		headers,
+		"Cross-Origin-Opener-Policy",
+		SeverityMedium,
+		"https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy",
+		coopWeakness,
+	)
+}
+
+// coopWeakness flags unsafe-none, the default that provides no isolation
+// from cross-origin openers/popups, and any value the spec doesn't define,
+// which browsers don't recognize and so also provides no isolation — same
+// treatment as a missing header in both cases.
+func coopWeakness(value string) (weak bool, message string) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "same-origin", "same-origin-allow-popups", "noopener-allow-popups":
+		return false, ""
+	case "unsafe-none":
+		return true, "unsafe-none is the default and provides no isolation from cross-origin openers/popups"
+	default:
+		return true, fmt.Sprintf("%q is not a recognized Cross-Origin-Opener-Policy value and provides no isolation", value)
+	}
 }
 
 type CORPChecker struct{}

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -20,6 +20,7 @@ func TestCheckersIdentity(t *testing.T) {
 		{scanner.FrameOptionsChecker{}, "X-Frame-Options", scanner.SeverityMedium, "DENY"},
 		{scanner.CSPChecker{}, "Content-Security-Policy", scanner.SeverityHigh, "default-src 'self'"},
 		{scanner.ReferrerPolicyChecker{}, "Referrer-Policy", scanner.SeverityLow, "strict-origin-when-cross-origin"},
+		{scanner.COOPChecker{}, "Cross-Origin-Opener-Policy", scanner.SeverityMedium, "same-origin"},
 		{scanner.CORPChecker{}, "Cross-Origin-Resource-Policy", scanner.SeverityMedium, "same-origin"},
 		{scanner.PermissionsPolicyChecker{}, "Permissions-Policy", scanner.SeverityMedium, "geolocation=()"},
 	}
@@ -130,6 +131,7 @@ func TestCheckValueIgnoresBlankDuplicateOccurrence(t *testing.T) {
 		{"FrameOptions", scanner.FrameOptionsChecker{}, http.Header{"X-Frame-Options": {"DENY", ""}}},
 		{"CSP", scanner.CSPChecker{}, http.Header{"Content-Security-Policy": {"default-src 'self'", ""}}},
 		{"ReferrerPolicy", scanner.ReferrerPolicyChecker{}, http.Header{"Referrer-Policy": {"strict-origin-when-cross-origin", ""}}},
+		{"COOP", scanner.COOPChecker{}, http.Header{"Cross-Origin-Opener-Policy": {"same-origin", ""}}},
 		{"CORP", scanner.CORPChecker{}, http.Header{"Cross-Origin-Resource-Policy": {"same-origin", ""}}},
 	}
 	for _, tt := range tests {
@@ -226,6 +228,44 @@ func TestReferrerPolicyWeakFallbackList(t *testing.T) {
 			}
 			if findings[0].Message == "" {
 				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestCOOPWeakValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"unsafe-none is the default no-op", "unsafe-none"},
+		{"unrecognized value", "garbage"},
+		{"restrict-properties is not a real COOP directive", "restrict-properties"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.COOPChecker{}.Check(http.Header{"Cross-Origin-Opener-Policy": {tt.value}})
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestCOOPAcceptsCaseInsensitiveValidValues(t *testing.T) {
+	tests := []string{
+		"same-origin", "SAME-ORIGIN",
+		"same-origin-allow-popups", "SAME-ORIGIN-ALLOW-POPUPS",
+		"noopener-allow-popups", "NOOPENER-ALLOW-POPUPS",
+	}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.COOPChecker{}.Check(http.Header{"Cross-Origin-Opener-Policy": {value}})
+			if findings[0].Status != scanner.StatusPass {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
 			}
 		})
 	}

--- a/internal/scanner/runall_test.go
+++ b/internal/scanner/runall_test.go
@@ -27,6 +27,7 @@ func TestRunAllFansOutAcrossDefaultCheckers(t *testing.T) {
 		"X-Frame-Options":              scanner.StatusMissing,
 		"Content-Security-Policy":      scanner.StatusPass,
 		"Referrer-Policy":              scanner.StatusMissing,
+		"Cross-Origin-Opener-Policy":   scanner.StatusMissing,
 		"Cross-Origin-Resource-Policy": scanner.StatusMissing,
 		"Permissions-Policy":           scanner.StatusMissing,
 	}

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -17,6 +17,7 @@ var allSecurityHeaders = map[string]string{
 	"X-Frame-Options":              "DENY",
 	"Content-Security-Policy":      "default-src 'self'",
 	"Referrer-Policy":              "no-referrer",
+	"Cross-Origin-Opener-Policy":   "same-origin",
 	"Cross-Origin-Resource-Policy": "same-origin",
 	"Permissions-Policy":           "geolocation=()",
 }
@@ -27,8 +28,8 @@ func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
 	t.Cleanup(srv.Close)
 
 	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, []string{srv.URL}, 1, nil)
-	if len(findings) != 7 {
-		t.Fatalf("Scan() returned %d findings, want 7", len(findings))
+	if len(findings) != 8 {
+		t.Fatalf("Scan() returned %d findings, want 8", len(findings))
 	}
 	for _, f := range findings {
 		if f.URL != srv.URL {
@@ -150,8 +151,8 @@ func TestScanCoversMultipleURLs(t *testing.T) {
 	t.Cleanup(srvB.Close)
 
 	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), nil, []string{srvA.URL, srvB.URL}, 2, nil)
-	if len(findings) != 14 {
-		t.Fatalf("Scan() returned %d findings, want 14 (7 per URL)", len(findings))
+	if len(findings) != 16 {
+		t.Fatalf("Scan() returned %d findings, want 16 (8 per URL)", len(findings))
 	}
 }
 
@@ -216,8 +217,8 @@ func TestScanReportsAllTargetsDespiteFailures(t *testing.T) {
 	if got := len(byURL[deadURL]); got != 1 {
 		t.Errorf("dead target has %d findings, want 1 error finding", got)
 	}
-	if got := len(byURL[healthy.URL]); got != 7 {
-		t.Errorf("healthy target has %d findings, want 7", got)
+	if got := len(byURL[healthy.URL]); got != 8 {
+		t.Errorf("healthy target has %d findings, want 8", got)
 	}
 }
 
@@ -242,8 +243,8 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), nil, urls, targets, nil)
 
 	assertAllStatus(t, findings, scanner.StatusMissing)
-	if len(findings) != targets*7 {
-		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*7)
+	if len(findings) != targets*8 {
+		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*8)
 	}
 }
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -10,6 +10,7 @@ header_pages:
   - checks/x-frame-options.md
   - checks/content-security-policy.md
   - checks/referrer-policy.md
+  - checks/cross-origin-opener-policy.md
   - checks/cross-origin-resource-policy.md
   - checks/set-cookie.md
   - checks/permissions-policy.md

--- a/site/checks/cross-origin-opener-policy.md
+++ b/site/checks/cross-origin-opener-policy.md
@@ -1,0 +1,42 @@
+---
+layout: page
+title: Cross-Origin-Opener-Policy
+permalink: /checks/cross-origin-opener-policy
+---
+
+**Severity:** medium
+
+## What it does
+
+Controls whether cross-origin popups/openers share this page's browsing context group. Without isolation, a same-origin-but-attacker-controlled popup (or a page this one opens) can hold a reference back to `window.opener` and manipulate it, and side-channel attacks like Spectre can exploit the shared context group.
+
+## Expected value
+
+```
+Cross-Origin-Opener-Policy: same-origin
+```
+
+or
+
+```
+Cross-Origin-Opener-Policy: same-origin-allow-popups
+```
+
+or
+
+```
+Cross-Origin-Opener-Policy: noopener-allow-popups
+```
+
+- `same-origin` — only same-origin documents share this page's browsing context group. Safest option.
+- `same-origin-allow-popups` — this page keeps its own browsing context group, but popups it opens aren't cut off from it.
+- `noopener-allow-popups` — severs the opener relationship even with same-origin popups that don't also set this header.
+
+## What mamori checks
+
+Presence of the header, and that its value is one of the three values that actually provide isolation. A missing header is reported as a medium-severity finding. A present header set to `unsafe-none` — the default, which provides no isolation — or any other unrecognized value (e.g. `restrict-properties`, not a real COOP directive) is reported as `WEAK`.
+
+## Further reading
+
+- [MDN: Cross-Origin-Opener-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy)
+- [OWASP: Secure Headers](https://owasp.org/www-project-secure-headers/)

--- a/site/index.md
+++ b/site/index.md
@@ -14,6 +14,7 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `X-Frame-Options` | medium | [docs](checks/x-frame-options) |
 | `Content-Security-Policy` | high | [docs](checks/content-security-policy) |
 | `Referrer-Policy` | low | [docs](checks/referrer-policy) |
+| `Cross-Origin-Opener-Policy` | medium | [docs](checks/cross-origin-opener-policy) |
 | `Cross-Origin-Resource-Policy` | medium | [docs](checks/cross-origin-resource-policy) |
 | `Set-Cookie` | high / medium | [docs](checks/set-cookie) |
 | `Permissions-Policy` | medium | [docs](checks/permissions-policy) |


### PR DESCRIPTION
## What

Adds `COOPChecker`, a plain `checkValue`-based checker for the `Cross-Origin-Opener-Policy` header, following the same shape as `CORPChecker` (not an `OriginProber`).

- **Pass:** `same-origin`, `same-origin-allow-popups`, `noopener-allow-popups` — all three provide real isolation from cross-origin openers/popups.
- **Weak (medium severity):** `unsafe-none` (the default — no isolation) and any unrecognized value, e.g. `restrict-properties` (not a real COOP directive).
- **Missing:** header absent or blank.

Slotted into `DefaultCheckers()` immediately before `CORPChecker` (position 6), grouping the two `Cross-Origin-*` isolation headers together while preserving issue-number order (COOP is #38, filed before CORP's #39). Same slot applied to the identity test table, `runall_test.go`'s fan-out map, `site/_config.yml`, and `site/index.md`.

## Why

Closes #38. Implemented fresh against current `main` per the issue's follow-up brief, since the prior attempt (#62, closed with merge conflicts) predates `CORPChecker` and the `OriginProber` interface. The extra `noopener-allow-popups` pass value (beyond the original brief's three) reflects MDN's current COOP spec and this project's existing principle — see `FrameOptionsChecker`/`corpWeakness` — of accepting any value that delivers real protection rather than only a literally-enumerated set.

## Test evidence

- New tests: `TestCOOPWeakValues`, `TestCOOPAcceptsCaseInsensitiveValidValues`, plus COOP entries added to `TestCheckersIdentity` and `TestCheckValueIgnoresBlankDuplicateOccurrence`.
- Updated fan-out/count assertions in `runall_test.go`, `scan_test.go`, and `cmd/mamori/main_test.go`'s `strongHeaders` fixture to account for the new checker.
- `go vet ./...`, `go build ./...`, and `go test ./...` all pass.
- Ran `/code-review` against the merge-base with `origin/main`: no findings.

Closes #38

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*