### PR TITLE
feat(scanner): add Cross-Origin-Embedder-Policy checker

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,3 +27,7 @@ _Avoid_: Priority, Risk level.
 **Isolation** (Cross-Origin-Opener-Policy):
 How completely a page's browsing context group is kept separate from cross-origin popups/openers it interacts with. COOPChecker treats `same-origin`, `same-origin-allow-popups`, and `noopener-allow-popups` as providing real isolation (`pass`); `unsafe-none` and any unrecognized value provide none (`weak`).
 _Avoid_: Cross-origin isolation — that's a distinct, broader platform concept (requires COOP *and* COEP together to unlock things like `SharedArrayBuffer`); don't conflate the header-level Checker with the platform-level guarantee.
+
+**Embedding** (Cross-Origin-Embedder-Policy):
+Whether a page requires every cross-origin subresource it loads to explicitly opt in — via CORP or CORS — before the browser lets it through, or accepts a policy that strips credentials from such requests instead. COEPChecker treats `require-corp` and `credentialless` as providing that guarantee (`pass`); `unsafe-none` and any unrecognized value provide none (`weak`), reported at `SeverityLow` since most sites correctly leave this unset to avoid breaking uncooperative cross-origin embeds — unlike every other header this scanner checks, absence here is often the deliberate, correct choice rather than an oversight.
+_Avoid_: Cross-origin isolation — see the Isolation entry's note; that's the platform-level guarantee this header only partly enables.

--- a/cmd/mamori/main_test.go
+++ b/cmd/mamori/main_test.go
@@ -21,6 +21,7 @@ func strongHeaders() map[string]string {
 		"Content-Security-Policy":      "default-src 'self'",
 		"Referrer-Policy":              "strict-origin-when-cross-origin",
 		"Cross-Origin-Opener-Policy":   "same-origin",
+		"Cross-Origin-Embedder-Policy": "require-corp",
 		"Cross-Origin-Resource-Policy": "same-origin",
 		"Permissions-Policy":           "geolocation=()",
 	}

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -19,6 +19,7 @@ func DefaultCheckers() []Checker {
 		CSPChecker{},
 		ReferrerPolicyChecker{},
 		COOPChecker{},
+		COEPChecker{},
 		CORPChecker{},
 		CookieChecker{},
 		PermissionsPolicyChecker{},
@@ -255,6 +256,37 @@ func coopWeakness(value string) (weak bool, message string) {
 		return true, "unsafe-none is the default and provides no isolation from cross-origin openers/popups"
 	default:
 		return true, fmt.Sprintf("%q is not a recognized Cross-Origin-Opener-Policy value and provides no isolation", value)
+	}
+}
+
+type COEPChecker struct{}
+
+func (COEPChecker) Check(headers http.Header) []Finding {
+	return checkValue(
+		headers,
+		"Cross-Origin-Embedder-Policy",
+		SeverityLow,
+		"https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy",
+		coepWeakness,
+	)
+}
+
+// coepWeakness flags unsafe-none, the default that lets this page load any
+// cross-origin resource without that resource opting in, and any value the
+// spec doesn't define, which browsers don't recognize and so also provides
+// no protection — same treatment as a missing header in both cases. Severity
+// is fixed lower than the other Cross-Origin-* checkers: unlike those,
+// leaving this header unset is often the deliberate, correct choice, since
+// enabling it breaks embedding of any cross-origin resource that isn't
+// itself CORP/CORS-compliant.
+func coepWeakness(value string) (weak bool, message string) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "require-corp", "credentialless":
+		return false, ""
+	case "unsafe-none":
+		return true, "unsafe-none is the default and lets this page load any cross-origin resource without that resource opting in"
+	default:
+		return true, fmt.Sprintf("%q is not a recognized Cross-Origin-Embedder-Policy value and provides no protection", value)
 	}
 }
 

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -21,6 +21,7 @@ func TestCheckersIdentity(t *testing.T) {
 		{scanner.CSPChecker{}, "Content-Security-Policy", scanner.SeverityHigh, "default-src 'self'"},
 		{scanner.ReferrerPolicyChecker{}, "Referrer-Policy", scanner.SeverityLow, "strict-origin-when-cross-origin"},
 		{scanner.COOPChecker{}, "Cross-Origin-Opener-Policy", scanner.SeverityMedium, "same-origin"},
+		{scanner.COEPChecker{}, "Cross-Origin-Embedder-Policy", scanner.SeverityLow, "require-corp"},
 		{scanner.CORPChecker{}, "Cross-Origin-Resource-Policy", scanner.SeverityMedium, "same-origin"},
 		{scanner.PermissionsPolicyChecker{}, "Permissions-Policy", scanner.SeverityMedium, "geolocation=()"},
 	}
@@ -132,6 +133,7 @@ func TestCheckValueIgnoresBlankDuplicateOccurrence(t *testing.T) {
 		{"CSP", scanner.CSPChecker{}, http.Header{"Content-Security-Policy": {"default-src 'self'", ""}}},
 		{"ReferrerPolicy", scanner.ReferrerPolicyChecker{}, http.Header{"Referrer-Policy": {"strict-origin-when-cross-origin", ""}}},
 		{"COOP", scanner.COOPChecker{}, http.Header{"Cross-Origin-Opener-Policy": {"same-origin", ""}}},
+		{"COEP", scanner.COEPChecker{}, http.Header{"Cross-Origin-Embedder-Policy": {"require-corp", ""}}},
 		{"CORP", scanner.CORPChecker{}, http.Header{"Cross-Origin-Resource-Policy": {"same-origin", ""}}},
 	}
 	for _, tt := range tests {
@@ -264,6 +266,42 @@ func TestCOOPAcceptsCaseInsensitiveValidValues(t *testing.T) {
 	for _, value := range tests {
 		t.Run(value, func(t *testing.T) {
 			findings := scanner.COOPChecker{}.Check(http.Header{"Cross-Origin-Opener-Policy": {value}})
+			if findings[0].Status != scanner.StatusPass {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
+			}
+		})
+	}
+}
+
+func TestCOEPWeakValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"unsafe-none is the default no-op", "unsafe-none"},
+		{"unrecognized value", "garbage"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.COEPChecker{}.Check(http.Header{"Cross-Origin-Embedder-Policy": {tt.value}})
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestCOEPAcceptsCaseInsensitiveValidValues(t *testing.T) {
+	tests := []string{
+		"require-corp", "REQUIRE-CORP",
+		"credentialless", "CREDENTIALLESS",
+	}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.COEPChecker{}.Check(http.Header{"Cross-Origin-Embedder-Policy": {value}})
 			if findings[0].Status != scanner.StatusPass {
 				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
 			}

--- a/internal/scanner/runall_test.go
+++ b/internal/scanner/runall_test.go
@@ -28,6 +28,7 @@ func TestRunAllFansOutAcrossDefaultCheckers(t *testing.T) {
 		"Content-Security-Policy":      scanner.StatusPass,
 		"Referrer-Policy":              scanner.StatusMissing,
 		"Cross-Origin-Opener-Policy":   scanner.StatusMissing,
+		"Cross-Origin-Embedder-Policy": scanner.StatusMissing,
 		"Cross-Origin-Resource-Policy": scanner.StatusMissing,
 		"Permissions-Policy":           scanner.StatusMissing,
 	}

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -18,6 +18,7 @@ var allSecurityHeaders = map[string]string{
 	"Content-Security-Policy":      "default-src 'self'",
 	"Referrer-Policy":              "no-referrer",
 	"Cross-Origin-Opener-Policy":   "same-origin",
+	"Cross-Origin-Embedder-Policy": "require-corp",
 	"Cross-Origin-Resource-Policy": "same-origin",
 	"Permissions-Policy":           "geolocation=()",
 }
@@ -28,8 +29,8 @@ func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
 	t.Cleanup(srv.Close)
 
 	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, []string{srv.URL}, 1, nil)
-	if len(findings) != 8 {
-		t.Fatalf("Scan() returned %d findings, want 8", len(findings))
+	if len(findings) != 9 {
+		t.Fatalf("Scan() returned %d findings, want 9", len(findings))
 	}
 	for _, f := range findings {
 		if f.URL != srv.URL {
@@ -151,8 +152,8 @@ func TestScanCoversMultipleURLs(t *testing.T) {
 	t.Cleanup(srvB.Close)
 
 	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), nil, []string{srvA.URL, srvB.URL}, 2, nil)
-	if len(findings) != 16 {
-		t.Fatalf("Scan() returned %d findings, want 16 (8 per URL)", len(findings))
+	if len(findings) != 18 {
+		t.Fatalf("Scan() returned %d findings, want 18 (9 per URL)", len(findings))
 	}
 }
 
@@ -217,8 +218,8 @@ func TestScanReportsAllTargetsDespiteFailures(t *testing.T) {
 	if got := len(byURL[deadURL]); got != 1 {
 		t.Errorf("dead target has %d findings, want 1 error finding", got)
 	}
-	if got := len(byURL[healthy.URL]); got != 8 {
-		t.Errorf("healthy target has %d findings, want 8", got)
+	if got := len(byURL[healthy.URL]); got != 9 {
+		t.Errorf("healthy target has %d findings, want 9", got)
 	}
 }
 
@@ -243,8 +244,8 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), nil, urls, targets, nil)
 
 	assertAllStatus(t, findings, scanner.StatusMissing)
-	if len(findings) != targets*8 {
-		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*8)
+	if len(findings) != targets*9 {
+		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*9)
 	}
 }
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -11,6 +11,7 @@ header_pages:
   - checks/content-security-policy.md
   - checks/referrer-policy.md
   - checks/cross-origin-opener-policy.md
+  - checks/cross-origin-embedder-policy.md
   - checks/cross-origin-resource-policy.md
   - checks/set-cookie.md
   - checks/permissions-policy.md

--- a/site/checks/cross-origin-embedder-policy.md
+++ b/site/checks/cross-origin-embedder-policy.md
@@ -34,3 +34,4 @@ Unlike mamori's other Cross-Origin-* checks, this finding is reported at low sev
 ## Further reading
 
 - [MDN: Cross-Origin-Embedder-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy)
+- [OWASP: Secure Headers](https://owasp.org/www-project-secure-headers/)

--- a/site/checks/cross-origin-embedder-policy.md
+++ b/site/checks/cross-origin-embedder-policy.md
@@ -1,0 +1,36 @@
+---
+layout: page
+title: Cross-Origin-Embedder-Policy
+permalink: /checks/cross-origin-embedder-policy
+---
+
+**Severity:** low
+
+## What it does
+
+Controls whether this page can load cross-origin resources (images, scripts, iframes, etc.) that haven't explicitly opted in via CORP or CORS. Requiring that opt-in is a prerequisite for cross-origin isolation, which unlocks powerful APIs like `SharedArrayBuffer` and gives stronger protection against Spectre-style side-channel attacks.
+
+## Expected value
+
+```
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+or
+
+```
+Cross-Origin-Embedder-Policy: credentialless
+```
+
+- `require-corp` — every cross-origin resource must set a CORP or CORS header explicitly allowing this page to load it. Safest option.
+- `credentialless` — cross-origin resources load without credentials unless they opt in via CORP; less disruptive than `require-corp` since it doesn't require existing resources to add a header, at the cost of stripping cookies/auth from those requests.
+
+## What mamori checks
+
+Presence of the header, and that its value is one of the two values that actually require cross-origin resources to opt in. A missing header, or a present header set to `unsafe-none` — the default, which lets this page load any cross-origin resource without that resource opting in — or any other unrecognized value, is reported as `WEAK`.
+
+Unlike mamori's other Cross-Origin-* checks, this finding is reported at low severity: leaving this header unset is often the deliberate, correct choice, since enabling it breaks embedding of any cross-origin resource that isn't itself CORP/CORS-compliant.
+
+## Further reading
+
+- [MDN: Cross-Origin-Embedder-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy)

--- a/site/index.md
+++ b/site/index.md
@@ -15,6 +15,7 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `Content-Security-Policy` | high | [docs](checks/content-security-policy) |
 | `Referrer-Policy` | low | [docs](checks/referrer-policy) |
 | `Cross-Origin-Opener-Policy` | medium | [docs](checks/cross-origin-opener-policy) |
+| `Cross-Origin-Embedder-Policy` | low | [docs](checks/cross-origin-embedder-policy) |
 | `Cross-Origin-Resource-Policy` | medium | [docs](checks/cross-origin-resource-policy) |
 | `Set-Cookie` | high / medium | [docs](checks/set-cookie) |
 | `Permissions-Policy` | medium | [docs](checks/permissions-policy) |


### PR DESCRIPTION
## What/why

Adds `COEPChecker`, a new default checker for the `Cross-Origin-Embedder-Policy` response header, following the existing `COOPChecker`/`CORPChecker`/`checkValue` pattern.

- `require-corp` and `credentialless` (case-insensitive) → pass — both require cross-origin resources to opt in before being loaded.
- Missing header, `unsafe-none`, or any unrecognized value → weak/missing finding.
- Severity is fixed at `SeverityLow` — deliberately lower than the scanner's other `Cross-Origin-*` checkers, since leaving this header unset is often the deliberate, correct choice (enabling it breaks embedding of any cross-origin resource that isn't itself CORP/CORS-compliant), unlike headers where absence is closer to an oversight.
- Finding references MDN's Cross-Origin-Embedder-Policy documentation page.
- No opt-in flag — it's unconditionally included in `DefaultCheckers()`, matching every other checker in the codebase.

Also adds the `CONTEXT.md` **Embedding** domain entry (per the issue's triage correction), a `site/checks/cross-origin-embedder-policy.md` doc page, and the corresponding `site/_config.yml`/`site/index.md` entries, mirroring the COOP checker's PR (#80).

## Test evidence

```
$ go build ./...
$ go vet ./...
$ gofmt -l .
$ go test ./...
ok  	github.com/PhyberApex/mamori/cmd/mamori	0.006s
ok  	github.com/PhyberApex/mamori/internal/config	0.008s
ok  	github.com/PhyberApex/mamori/internal/scanner	0.235s
```

New unit tests cover all five acceptance-criteria cases (`require-corp` pass, `credentialless` pass, missing header, `unsafe-none`, and an unrecognized value), plus the checker's inclusion in the shared identity/blank-duplicate-header test tables and the default checker set (finding counts bumped 8→9 per target across `runall_test.go`/`scan_test.go`/`cmd/mamori/main_test.go`).

Ran `/code-review` (Standards + Spec axes) against the merge-base with `origin/main`; fixed the one hard finding it surfaced (the new doc page was missing the "OWASP: Secure Headers" further-reading link every other check page — but one — carries).

Closes #40

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*