### PR TITLE
feat(scanner): add Cache-Control checker

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,8 +5,8 @@ A concurrent scanner that checks HTTP(S) endpoints for missing or misconfigured 
 ## Language
 
 **Checker**:
-A single security-header rule that inspects a response's headers and produces zero or more Findings.
-_Avoid_: Rule, Validator, Inspector.
+A single security-header rule that inspects a response's headers and produces zero or more Findings. Every Checker runs against every target unconditionally — mamori has no concept of endpoint sensitivity (a distinction between, say, an API response and a static asset). A Checker that needs a real sensitivity signal to avoid false positives should earn that as its own decision, not assume the concept already exists.
+_Avoid_: Rule, Validator, Inspector, sensitive endpoint, likely-sensitive.
 
 **Finding**:
 The result of running one Checker against one target — a header name, a Status, a Severity, a reference link, and (when the Status is `weak`) a message explaining what's wrong.

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -26,6 +26,7 @@ func DefaultCheckers() []Checker {
 		BannerDisclosureChecker{},
 		CORSChecker{},
 		XSSProtectionChecker{},
+		CacheControlChecker{},
 	}
 }
 
@@ -387,6 +388,42 @@ func isEnabledXSSProtectionValue(value string) bool {
 		}
 	}
 	return true
+}
+
+const cacheControlReference = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control"
+
+type CacheControlChecker struct{}
+
+func (CacheControlChecker) Check(headers http.Header) []Finding {
+	return checkValue(
+		headers,
+		"Cache-Control",
+		SeverityMedium,
+		cacheControlReference,
+		cacheControlWeakness,
+	)
+}
+
+// cacheControlWeakness flags a value that lacks a directive actually
+// preventing storage: no-store and private are the only directives that keep
+// a response out of shared/private caches respectively. no-cache alone only
+// forces revalidation without preventing storage, and a bare public,
+// max-age=N with nothing else, or a value with only unrecognized directives,
+// all leave the response cacheable by any shared cache (proxy/CDN) in the
+// path.
+//
+// Cache-Control's directives are a comma-separated list, unlike the
+// semicolon-separated directives HSTS/CSP use, so parsing must split on
+// commas.
+func cacheControlWeakness(value string) (weak bool, message string) {
+	for _, directive := range strings.Split(value, ",") {
+		name, _, _ := strings.Cut(strings.TrimSpace(directive), "=")
+		switch strings.ToLower(strings.TrimSpace(name)) {
+		case "no-store", "private":
+			return false, ""
+		}
+	}
+	return true, fmt.Sprintf("%q contains neither no-store nor private and permits storage in shared caches", value)
 }
 
 const cookieReference = "https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html"

--- a/internal/scanner/checkers.go
+++ b/internal/scanner/checkers.go
@@ -405,9 +405,10 @@ func (CacheControlChecker) Check(headers http.Header) []Finding {
 }
 
 // cacheControlWeakness flags a value that lacks a directive actually
-// preventing storage: no-store and private are the only directives that keep
-// a response out of shared/private caches respectively. no-cache alone only
-// forces revalidation without preventing storage, and a bare public,
+// preventing storage: no-store keeps a response out of every cache, and
+// private keeps it out of shared caches (proxy/CDN) while still allowing the
+// browser's own cache to store it — either is enough to pass. no-cache alone
+// only forces revalidation without preventing storage, and a bare public,
 // max-age=N with nothing else, or a value with only unrecognized directives,
 // all leave the response cacheable by any shared cache (proxy/CDN) in the
 // path.

--- a/internal/scanner/checkers_test.go
+++ b/internal/scanner/checkers_test.go
@@ -25,6 +25,7 @@ func TestCheckersIdentity(t *testing.T) {
 		{scanner.CORPChecker{}, "Cross-Origin-Resource-Policy", scanner.SeverityMedium, "same-origin"},
 		{scanner.PermissionsPolicyChecker{}, "Permissions-Policy", scanner.SeverityMedium, "geolocation=()"},
 		{scanner.XSSProtectionChecker{}, "X-XSS-Protection", scanner.SeverityLow, "0"},
+		{scanner.CacheControlChecker{}, "Cache-Control", scanner.SeverityMedium, "no-store"},
 	}
 
 	for _, tt := range tests {
@@ -146,6 +147,7 @@ func TestCheckValueIgnoresBlankDuplicateOccurrence(t *testing.T) {
 		{"COOP", scanner.COOPChecker{}, http.Header{"Cross-Origin-Opener-Policy": {"same-origin", ""}}},
 		{"COEP", scanner.COEPChecker{}, http.Header{"Cross-Origin-Embedder-Policy": {"require-corp", ""}}},
 		{"CORP", scanner.CORPChecker{}, http.Header{"Cross-Origin-Resource-Policy": {"same-origin", ""}}},
+		{"CacheControl", scanner.CacheControlChecker{}, http.Header{"Cache-Control": {"no-store", ""}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -459,6 +461,70 @@ func TestCORPAcceptsCaseInsensitiveValidValues(t *testing.T) {
 				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
 			}
 		})
+	}
+}
+
+func TestCacheControlWeakValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"no-cache alone forces revalidation but doesn't prevent storage", "no-cache"},
+		{"bare public with max-age", "public, max-age=3600"},
+		{"bare max-age with no other directive", "max-age=3600"},
+		{"only unrecognized directives", "stale-while-revalidate=60"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := scanner.CacheControlChecker{}.Check(http.Header{"Cache-Control": {tt.value}})
+			if findings[0].Status != scanner.StatusWeak {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+			}
+			if findings[0].Message == "" {
+				t.Error("Message is empty, want an explanation")
+			}
+		})
+	}
+}
+
+func TestCacheControlAcceptsNoStoreOrPrivate(t *testing.T) {
+	tests := []string{
+		"no-store",
+		"private",
+		"no-store, max-age=0",
+		"max-age=0, private",
+		"public, no-store",
+		"NO-STORE",
+		"Private",
+	}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			findings := scanner.CacheControlChecker{}.Check(http.Header{"Cache-Control": {value}})
+			if findings[0].Status != scanner.StatusPass {
+				t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusPass)
+			}
+		})
+	}
+}
+
+func TestCacheControlFlagsWeakAmongDuplicateHeaders(t *testing.T) {
+	// A misconfigured proxy/CDN can append a second Cache-Control header
+	// instead of overwriting the origin's. headers.Get would only see
+	// whichever value happens to be first, so the reported status must not
+	// depend on that order.
+	headers := http.Header{"Cache-Control": {"no-store", "public, max-age=3600"}}
+	findings := scanner.CacheControlChecker{}.Check(headers)
+	if findings[0].Status != scanner.StatusWeak {
+		t.Errorf("Status = %q, want %q", findings[0].Status, scanner.StatusWeak)
+	}
+	if findings[0].Message == "" {
+		t.Error("Message is empty, want an explanation")
+	}
+
+	reversed := http.Header{"Cache-Control": {"public, max-age=3600", "no-store"}}
+	findings = scanner.CacheControlChecker{}.Check(reversed)
+	if findings[0].Status != scanner.StatusWeak {
+		t.Errorf("Status = %q, want %q (order should not matter)", findings[0].Status, scanner.StatusWeak)
 	}
 }
 

--- a/internal/scanner/runall_test.go
+++ b/internal/scanner/runall_test.go
@@ -32,6 +32,7 @@ func TestRunAllFansOutAcrossDefaultCheckers(t *testing.T) {
 		"Cross-Origin-Resource-Policy": scanner.StatusMissing,
 		"Permissions-Policy":           scanner.StatusMissing,
 		"X-XSS-Protection":             scanner.StatusMissing,
+		"Cache-Control":                scanner.StatusMissing,
 	}
 	if len(findings) != len(want) {
 		t.Fatalf("RunAll() returned %d findings, want %d", len(findings), len(want))

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -22,6 +22,7 @@ var allSecurityHeaders = map[string]string{
 	"Cross-Origin-Resource-Policy": "same-origin",
 	"Permissions-Policy":           "geolocation=()",
 	"X-XSS-Protection":             "0",
+	"Cache-Control":                "no-store",
 }
 
 func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
@@ -30,8 +31,8 @@ func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
 	t.Cleanup(srv.Close)
 
 	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, []string{srv.URL}, 1, nil)
-	if len(findings) != 10 {
-		t.Fatalf("Scan() returned %d findings, want 10", len(findings))
+	if len(findings) != 11 {
+		t.Fatalf("Scan() returned %d findings, want 11", len(findings))
 	}
 	for _, f := range findings {
 		if f.URL != srv.URL {
@@ -153,8 +154,8 @@ func TestScanCoversMultipleURLs(t *testing.T) {
 	t.Cleanup(srvB.Close)
 
 	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), nil, []string{srvA.URL, srvB.URL}, 2, nil)
-	if len(findings) != 20 {
-		t.Fatalf("Scan() returned %d findings, want 20 (10 per URL)", len(findings))
+	if len(findings) != 22 {
+		t.Fatalf("Scan() returned %d findings, want 22 (11 per URL)", len(findings))
 	}
 }
 
@@ -219,8 +220,8 @@ func TestScanReportsAllTargetsDespiteFailures(t *testing.T) {
 	if got := len(byURL[deadURL]); got != 1 {
 		t.Errorf("dead target has %d findings, want 1 error finding", got)
 	}
-	if got := len(byURL[healthy.URL]); got != 10 {
-		t.Errorf("healthy target has %d findings, want 10", got)
+	if got := len(byURL[healthy.URL]); got != 11 {
+		t.Errorf("healthy target has %d findings, want 11", got)
 	}
 }
 
@@ -245,8 +246,8 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), nil, urls, targets, nil)
 
 	assertAllStatus(t, findings, scanner.StatusMissing)
-	if len(findings) != targets*10 {
-		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*10)
+	if len(findings) != targets*11 {
+		t.Fatalf("Scan() returned %d findings, want %d", len(findings), targets*11)
 	}
 }
 

--- a/site/checks/cache-control.md
+++ b/site/checks/cache-control.md
@@ -1,0 +1,36 @@
+---
+layout: page
+title: Cache-Control
+permalink: /checks/cache-control
+---
+
+**Severity:** medium
+
+## What it does
+
+Controls whether a response may be stored by caches sitting between the origin and the client — browser cache, but also any shared proxy or CDN in the path. A response that omits `no-store`/`private` can end up cached somewhere shared, and later served to a different user. This is infrastructure-conditional rather than directly browser-exploitable: it only leaks data if a shared cache/proxy/CDN actually sits in the path.
+
+## Expected value
+
+```
+Cache-Control: no-store
+```
+
+or
+
+```
+Cache-Control: private
+```
+
+- `no-store` — the response must not be stored by any cache. Safest option.
+- `private` — the response may be stored by the browser's own cache, but not by a shared cache (proxy/CDN).
+
+## What mamori checks
+
+Presence of the header, and that its value contains `no-store` and/or `private` among its (comma-separated) directives. A missing header is reported as a medium-severity finding. A present header whose directives contain neither `no-store` nor `private` is reported as `WEAK` — this includes `no-cache` alone (it only forces revalidation, it doesn't prevent storage), a bare `public`, a bare `max-age=N` with no other directive, and any value with only unrecognized directives.
+
+This checker runs unconditionally against every scanned target — mamori has no concept of endpoint sensitivity (a distinction between, say, an API response and a static asset), so it doesn't attempt to guess which targets are "sensitive" before checking.
+
+## Further reading
+
+- [MDN: Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)

--- a/site/index.md
+++ b/site/index.md
@@ -22,5 +22,6 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `Server` / `X-Powered-By` | low | [docs](checks/banner-disclosure) |
 | `Access-Control-Allow-Origin` | high | [docs](checks/cors) |
 | `X-XSS-Protection` | low | [docs](checks/x-xss-protection) |
+| `Cache-Control` | medium | [docs](checks/cache-control) |
 | `<script>` / `<link>` (SRI) | low | [docs](checks/subresource-integrity) |
 | Mixed Content | medium | [docs](checks/mixed-content) |


### PR DESCRIPTION
## What

Adds `CacheControlChecker` to the default checker set. It inspects the `Cache-Control` header of every scanned target unconditionally and reports:

- **Missing** — no `Cache-Control` header (or only blank occurrences).
- **Weak** — present, but its (comma-separated, case-insensitive) directives contain neither `no-store` nor `private`. This covers `no-cache` alone (only forces revalidation, doesn't prevent storage), a bare `public`, a bare `max-age=N`, and values with only unrecognized directives.
- **Pass** — directives contain `no-store` and/or `private` anywhere.

Severity is `Medium`, matching `CORPChecker` — this is a real but infrastructure-conditional information-disclosure risk (needs a shared cache/proxy/CDN in the path to actually leak data), not directly browser-exploitable. Reference link points to MDN's Cache-Control page.

Built on the same `checkValue` presence/value-validation pattern every other single-header checker uses (see `CORPChecker`/`HSTSChecker`), with one deliberate deviation: directive parsing splits on commas, not semicolons, since Cache-Control's directive list is comma-separated (unlike CSP/HSTS).

Also updates `CONTEXT.md`'s `Checker` glossary entry per the Agent Brief addendum, codifying that mamori has no concept of "endpoint sensitivity" and every Checker (including this one) runs unconditionally against every target regardless of content type — deliberately out of scope for this ticket.

## Why

Responses that omit cache-prevention directives can be stored by an intermediate shared cache/proxy/CDN and later served to a different user — a real, if infrastructure-conditional, information-disclosure risk mamori didn't check for until now.

## Test evidence

- New unit tests in `internal/scanner/checkers_test.go` cover: missing header, `no-store`/`private` pass (alone, combined, case-insensitive), weak values (`no-cache`, `public, max-age=3600`, bare `max-age`, unrecognized-only directives), and weak-wins-among-duplicate-headers ordering.
- `runall_test.go` and `scan_test.go` updated for the new checker's presence in `DefaultCheckers()`.
- `go build ./...`, `go vet ./...`, `gofmt -l .` all clean.
- `go test ./...`:
  ```
  ok  	github.com/PhyberApex/mamori/cmd/mamori	0.006s
  ok  	github.com/PhyberApex/mamori/internal/config	0.007s
  ok  	github.com/PhyberApex/mamori/internal/scanner	0.235s
  ```
- Ran `/mattpocock-skills:code-review` (Standards + Spec axes) against the merge-base with `origin/main`; Spec axis found no gaps, Standards axis flagged one judgement call (a type-level doc comment restating the generic CONTEXT.md rule as if checker-specific) — fixed by removing the comment to match sibling checkers without a dedicated glossary entry.

Closes #44

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*