### PR TITLE
feat(scanner): add opt-in sensitive-path exposure checker

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,8 +13,16 @@ The result of running one Checker against one target — a header name, a Status
 _Avoid_: Result, Issue, Violation.
 
 **Status**:
-Where a header landed after a Checker ran: `pass` (present and effective), `missing` (absent or blank), `weak` (present but a known no-op value), `error` (the scan itself failed, e.g. an unreachable target).
+Where a header landed after a Checker ran: `pass` (present and effective), `missing` (absent or blank), `weak` (present but a known no-op value), `exposed` (a PathChecker's probed path was confirmed reachable), `error` (the scan itself failed, e.g. an unreachable target).
 _Avoid_: Result, Outcome.
+
+**PathChecker**:
+A checker category parallel to Checker (headers) and BodyChecker (body): declares a path to probe at a target's origin and judges the probe response's status code rather than headers or a body. Off by default and opt-in only (`-check-exposed-paths` / `MAMORI_CHECK_EXPOSED_PATHS` / `checkExposedPaths`, plus `-exposed-path` / `exposedPaths` to extend the built-in path list), since it issues requests to paths beyond the one the user named as a target. Before probing any configured path for a target, Scan sends one baseline probe to a randomized, deliberately-nonexistent path; a target that doesn't answer that with `404` is treated as unreliable for this check (a soft-404/catch-all server) and produces a single `error` Finding instead of probing anything configured.
+_Avoid_: Prober — too close to OriginProber, a distinct existing mechanism (see below) that probes the *same* target URL with a synthetic header rather than a *different* path.
+
+**Exposed**:
+A Status for a PathChecker Finding whose probed path came back `200`/`206` (a full-severity hit, the path is directly readable) or `403` (still a hit — the server treated the path differently from an unrecognized one — but one severity step down, since access is at least blocked). Kept distinct from `missing`/`weak`, which both describe header state on the target URL itself, not a separate path's reachability.
+_Avoid_: Found, Discovered — too generic; `exposed` names the specific problem (a sensitive path is reachable), matching how `weak` names its problem rather than using a generic "Invalid".
 
 **Weak**:
 A Status for a header that is present but whose value provides none of the protection the header exists for. Kept distinct from `missing` because "isn't set" and "set but useless" are different problems for a reader to fix.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,7 +9,7 @@ A single security-header rule that inspects a response's headers and produces ze
 _Avoid_: Rule, Validator, Inspector.
 
 **Finding**:
-The result of running one Checker against one target — a header name, a Status, a Severity, a reference link, and (when the Status is `weak`) a message explaining what's wrong.
+The result of running one Checker against one target — a Status, a Severity, a reference link, and (when the Status is `weak` or `exposed`) a message explaining what's wrong. Its `header` field names the specific thing being reported on: a header name for a Checker/BodyChecker Finding, or the probed path (e.g. `.git/config`) for a PathChecker Finding — reused rather than adding a path-specific field, so every reporter renders both kinds through the same field.
 _Avoid_: Result, Issue, Violation.
 
 **Status**:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Full reference for every check mamori performs is available at
 | `-o` | `terminal` | output format: `terminal`, `json`, or `sarif` |
 | `-fail-on` | `none` | exit non-zero on findings at or above this severity: `low`, `medium`, `high`, or `none` |
 | `-H` | *(none)* | custom request header `'Key: Value'`, e.g. `-H 'Authorization: Bearer xyz'` (repeatable) |
+| `-check-exposed-paths` | `false` | probe each target's origin for well-known sensitive paths (`.git`, `.env`, backups, ...) |
+| `-exposed-path` | *(none)* | extra path to probe in addition to the default list (repeatable; also enables `-check-exposed-paths`) |
 | `-config` | *(none)* | path to a YAML config file |
 | `-v`, `-version` | `false` | print the version and exit, performing no scan |
 
@@ -92,6 +94,21 @@ finding is responsible.
 auth (e.g. `-H 'Authorization: Bearer xyz' -H 'Cookie: session=abc'`). It
 has no environment variable or config file equivalent.
 
+`-check-exposed-paths` turns on an additional, opt-in check category: for
+each target, mamori probes its origin for well-known sensitive paths
+(version control metadata, `.env` files, credential stores, common backup
+files) and flags any that respond `200`/`206` (readable) or `403` (exists,
+but blocked). This is off by default and separate from every other check,
+since it issues requests to paths the user never named as a target — a more
+intrusive scan than reading headers on the URL that was actually passed in.
+`-exposed-path` adds an extra path to the built-in list (repeatable) and, on
+its own, also turns the category on — supplying a path can't be a silent
+no-op. Before probing any configured path for a target, mamori first sends
+one request to a randomized, deliberately-nonexistent path at that target's
+origin; if the target doesn't answer that with `404`, it's treated as
+unreliable for this check (e.g. a catch-all/soft-404 server) and mamori
+reports a single error for that target instead of probing anything else.
+
 ### Environment variables
 
 Each flag can also be set via an environment variable; CLI flags take
@@ -103,7 +120,10 @@ precedence.
 | `MAMORI_TIMEOUT` | `-timeout` |
 | `MAMORI_OUTPUT` | `-o` |
 | `MAMORI_FAIL_ON` | `-fail-on` |
+| `MAMORI_CHECK_EXPOSED_PATHS` | `-check-exposed-paths` |
 | `MAMORI_CONFIG` | `-config` |
+
+`-exposed-path` has no environment variable equivalent, the same as `-H`.
 
 ### Config file
 
@@ -117,6 +137,9 @@ output: json
 targets:
   - https://example.com
   - https://example.org
+checkExposedPaths: true
+exposedPaths:
+  - debug.log
 suppressions:
   - header: Content-Security-Policy
     host: https://cdn.example.com

--- a/cmd/mamori/main.go
+++ b/cmd/mamori/main.go
@@ -65,7 +65,8 @@ func run(args []string, stdin io.Reader, out io.Writer) error {
 		return err
 	}
 	client := &http.Client{Timeout: cfg.Timeout}
-	findings := scanner.Scan(context.Background(), client, scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), urls, cfg.Workers, http.Header(cfg.Headers))
+	pathCheckers := scanner.PathCheckersFor(cfg.CheckExposedPaths, cfg.ExtraExposedPaths)
+	findings := scanner.Scan(context.Background(), client, scanner.DefaultCheckers(), scanner.DefaultBodyCheckers(), pathCheckers, urls, cfg.Workers, http.Header(cfg.Headers))
 	scanner.ApplySuppressions(findings, cfg.Suppressions)
 	if err := reporterFor(cfg.Output).Report(findings, out); err != nil {
 		return err

--- a/cmd/mamori/main_test.go
+++ b/cmd/mamori/main_test.go
@@ -213,6 +213,69 @@ func TestRunSuppressedFindingDoesNotTripFailOnButStaysInOutput(t *testing.T) {
 	}
 }
 
+func TestRunDefaultDoesNotProbeExposedPaths(t *testing.T) {
+	var probed bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.git/config" {
+			probed = true
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := run([]string{srv.URL}, nil, io.Discard); err != nil {
+		t.Fatalf("run() returned error: %v", err)
+	}
+	if probed {
+		t.Error("run() probed /.git/config with -check-exposed-paths unset, want the category off by default")
+	}
+}
+
+func TestRunCheckExposedPathsFlagFindsExposedPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.env" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	var buf bytes.Buffer
+	if err := run([]string{"-check-exposed-paths", "-o", "json", srv.URL}, nil, &buf); err != nil {
+		t.Fatalf("run() returned error: %v", err)
+	}
+
+	var sawExposed bool
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		var f map[string]any
+		if err := json.Unmarshal([]byte(line), &f); err != nil {
+			t.Fatalf("line is not valid JSON: %v\nline: %s", err, line)
+		}
+		if f["status"] == "exposed" && f["header"] == ".env" {
+			sawExposed = true
+		}
+	}
+	if !sawExposed {
+		t.Errorf("run() with -check-exposed-paths did not report .env as exposed\noutput:\n%s", buf.String())
+	}
+}
+
+func TestRunFailOnGatesOnExposedFinding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.env" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	err := run([]string{"-check-exposed-paths", "-fail-on", "high", srv.URL}, nil, io.Discard)
+	if !errors.Is(err, errFailThreshold) {
+		t.Errorf("run() with an exposed .env and -fail-on high returned %v, want errFailThreshold", err)
+	}
+}
+
 func TestRunFailOnFlagOverridesEnvVar(t *testing.T) {
 	url := headerServer(t, nil)
 	t.Setenv("MAMORI_FAIL_ON", "low")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,19 @@ type Config struct {
 	// set — so the zero value (nil) is already the correct default: no
 	// suppressions.
 	Suppressions []scanner.Suppression
+	// CheckExposedPaths turns on the sensitive-path exposure checker
+	// category, probing every target's origin for the built-in default path
+	// list. Off by default: unlike every other check, it issues requests to
+	// paths the user never named as a target — flag + env + config-file,
+	// following the pattern workers/timeout/output/fail-on already use.
+	CheckExposedPaths bool
+	// ExtraExposedPaths adds paths to the default list CheckExposedPaths
+	// probes, on top of it rather than instead of it. Supplying at least one
+	// entry here enables the category on its own, even when
+	// CheckExposedPaths is false — adding a path can't be a silent no-op.
+	// The zero value (nil) is already the correct default: no extra paths.
+	// Flag + config-file only, no env var, the same pattern -H follows.
+	ExtraExposedPaths ExposedPaths
 }
 
 // Headers is http.Header under the flag package's Value contract: a defined
@@ -91,6 +104,19 @@ func (h *Headers) Set(v string) error {
 		*h = Headers{}
 	}
 	http.Header(*h).Set(key, strings.TrimSpace(value))
+	return nil
+}
+
+// ExposedPaths is a []string under the flag package's Value contract, the
+// same wrapper pattern Headers uses above: a defined type so *ExposedPaths
+// can carry String/Set methods a plain []string can't. -exposed-path is
+// repeatable, so Set appends rather than replacing on each call.
+type ExposedPaths []string
+
+func (p *ExposedPaths) String() string { return strings.Join(*p, ", ") }
+
+func (p *ExposedPaths) Set(v string) error {
+	*p = append(*p, v)
 	return nil
 }
 
@@ -196,6 +222,8 @@ func registerFlags(cfg *Config) (*flag.FlagSet, *string) {
 	fs.BoolVar(&cfg.Version, "v", false, "print version and exit")
 	fs.BoolVar(&cfg.Version, "version", false, "print version and exit")
 	fs.Var(&cfg.Headers, "H", "custom request header 'Key: Value', e.g. -H 'Authorization: Bearer xyz' (repeatable)")
+	fs.BoolVar(&cfg.CheckExposedPaths, "check-exposed-paths", cfg.CheckExposedPaths, "probe each target's origin for well-known sensitive paths (.git, .env, backups, ...); off by default since it requests paths beyond the scanned URL itself")
+	fs.Var(&cfg.ExtraExposedPaths, "exposed-path", "extra path to probe in addition to the default list, e.g. -exposed-path 'debug.log' (repeatable; also enables -check-exposed-paths)")
 	var configPath string
 	fs.StringVar(&configPath, "config", "", "path to YAML config file (env MAMORI_CONFIG; default: .mamori.yaml in the working directory if present)")
 	return fs, &configPath
@@ -238,6 +266,13 @@ func Resolve(args []string, getenv func(string) string) (Config, []string, error
 		if err := cfg.FailOn.Set(v); err != nil {
 			return Config{}, nil, fmt.Errorf("MAMORI_FAIL_ON: %w", err)
 		}
+	}
+	if v := getenv("MAMORI_CHECK_EXPOSED_PATHS"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return Config{}, nil, fmt.Errorf("MAMORI_CHECK_EXPOSED_PATHS: %q is not a valid boolean (true/false)", v)
+		}
+		cfg.CheckExposedPaths = b
 	}
 
 	fs, _ := registerFlags(&cfg)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -188,6 +188,75 @@ func TestResolveDefaultsToNoHeaders(t *testing.T) {
 	}
 }
 
+func TestResolveDefaultsToExposedPathsDisabled(t *testing.T) {
+	cfg, _, err := config.Resolve(nil, noEnv)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.CheckExposedPaths {
+		t.Error("CheckExposedPaths = true, want false by default")
+	}
+	if len(cfg.ExtraExposedPaths) != 0 {
+		t.Errorf("ExtraExposedPaths = %v, want empty by default", cfg.ExtraExposedPaths)
+	}
+}
+
+func TestResolveCheckExposedPathsFlag(t *testing.T) {
+	cfg, _, err := config.Resolve([]string{"-check-exposed-paths"}, noEnv)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if !cfg.CheckExposedPaths {
+		t.Error("CheckExposedPaths = false, want true from -check-exposed-paths")
+	}
+}
+
+func TestResolveCheckExposedPathsEnvVar(t *testing.T) {
+	cfg, _, err := config.Resolve(nil, envWith(map[string]string{"MAMORI_CHECK_EXPOSED_PATHS": "true"}))
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if !cfg.CheckExposedPaths {
+		t.Error("CheckExposedPaths = false, want true from MAMORI_CHECK_EXPOSED_PATHS")
+	}
+}
+
+func TestResolveCheckExposedPathsFlagOverridesEnvVar(t *testing.T) {
+	cfg, _, err := config.Resolve(
+		[]string{"-check-exposed-paths=false"},
+		envWith(map[string]string{"MAMORI_CHECK_EXPOSED_PATHS": "true"}),
+	)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if cfg.CheckExposedPaths {
+		t.Error("CheckExposedPaths = true, want false: -check-exposed-paths=false overriding MAMORI_CHECK_EXPOSED_PATHS=true")
+	}
+}
+
+func TestResolveRejectsInvalidCheckExposedPathsEnvVar(t *testing.T) {
+	if _, _, err := config.Resolve(nil, envWith(map[string]string{"MAMORI_CHECK_EXPOSED_PATHS": "sure"})); err == nil {
+		t.Error("Resolve() with MAMORI_CHECK_EXPOSED_PATHS=sure returned nil error, want error")
+	}
+}
+
+func TestResolveParsesRepeatableExposedPathFlag(t *testing.T) {
+	cfg, _, err := config.Resolve(
+		[]string{"-exposed-path", "debug.log", "-exposed-path", "old-backup.sql"},
+		noEnv,
+	)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	want := []string{"debug.log", "old-backup.sql"}
+	if !reflect.DeepEqual([]string(cfg.ExtraExposedPaths), want) {
+		t.Errorf("ExtraExposedPaths = %v, want %v", cfg.ExtraExposedPaths, want)
+	}
+	if cfg.CheckExposedPaths {
+		t.Error("CheckExposedPaths = true, want false: -exposed-path alone doesn't set the boolean flag itself (PathCheckersFor is what treats it as enabling)")
+	}
+}
+
 func TestResolveFailOnNoneFlagOverridesEnv(t *testing.T) {
 	cfg, _, err := config.Resolve(
 		[]string{"-fail-on", "none"},

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -24,6 +24,11 @@ type fileConfig struct {
 	Timeout      *string               `yaml:"timeout"`
 	Output       *Output               `yaml:"output"`
 	Suppressions []scanner.Suppression `yaml:"suppressions"`
+	// CheckExposedPaths and ExposedPaths mirror the -check-exposed-paths and
+	// -exposed-path flags. ExposedPaths has no env var, following the -H
+	// flag's precedent for a repeatable list-shaped setting.
+	CheckExposedPaths *bool    `yaml:"checkExposedPaths"`
+	ExposedPaths      []string `yaml:"exposedPaths"`
 }
 
 // resolveConfigPath decides which config file, if any, supplies the config
@@ -96,6 +101,13 @@ func applyFileConfig(cfg *Config, fc fileConfig, path string) error {
 		return fmt.Errorf("%s: %w", path, err)
 	}
 	cfg.Suppressions = fc.Suppressions
+	if fc.CheckExposedPaths != nil {
+		cfg.CheckExposedPaths = *fc.CheckExposedPaths
+	}
+	// Additive, not a replace: applyFileConfig runs before the -exposed-path
+	// flag is parsed, so appending here lets a repeated -exposed-path flag
+	// extend what the config file already set rather than clobbering it.
+	cfg.ExtraExposedPaths = append(cfg.ExtraExposedPaths, fc.ExposedPaths...)
 	return nil
 }
 

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -265,6 +265,53 @@ suppressions:
 	}
 }
 
+func TestResolveConfigFileLoadsCheckExposedPathsAndExposedPaths(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", `
+checkExposedPaths: true
+exposedPaths:
+  - debug.log
+  - old-backup.sql
+`)
+
+	cfg, _, err := config.Resolve([]string{"-config", path}, noEnv)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	if !cfg.CheckExposedPaths {
+		t.Error("CheckExposedPaths = false, want true from config file")
+	}
+	want := []string{"debug.log", "old-backup.sql"}
+	if len(cfg.ExtraExposedPaths) != len(want) {
+		t.Fatalf("ExtraExposedPaths = %v, want %v", cfg.ExtraExposedPaths, want)
+	}
+	for i, p := range want {
+		if cfg.ExtraExposedPaths[i] != p {
+			t.Errorf("ExtraExposedPaths[%d] = %q, want %q", i, cfg.ExtraExposedPaths[i], p)
+		}
+	}
+}
+
+func TestResolveExposedPathFlagExtendsConfigFileList(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "mamori.yaml", `
+exposedPaths:
+  - debug.log
+`)
+
+	cfg, _, err := config.Resolve([]string{"-config", path, "-exposed-path", "old-backup.sql"}, noEnv)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+	want := map[string]bool{"debug.log": true, "old-backup.sql": true}
+	if len(cfg.ExtraExposedPaths) != len(want) {
+		t.Fatalf("ExtraExposedPaths = %v, want both the config-file and flag entries", cfg.ExtraExposedPaths)
+	}
+	for _, p := range cfg.ExtraExposedPaths {
+		if !want[p] {
+			t.Errorf("unexpected ExtraExposedPaths entry %q", p)
+		}
+	}
+}
+
 func TestResolveWithNoConfigFilePresentIsUnchanged(t *testing.T) {
 	t.Chdir(t.TempDir())
 

--- a/internal/scanner/exposure.go
+++ b/internal/scanner/exposure.go
@@ -17,9 +17,9 @@ type PathChecker interface {
 	// target's scheme+host regardless of any path component in the target
 	// URL itself.
 	Path() string
-	// Check judges the probe response's status code, returning no Finding
+	// CheckStatus judges the probe response's status code, returning no Finding
 	// for anything that isn't a confirmed hit.
-	Check(statusCode int) []Finding
+	CheckStatus(statusCode int) []Finding
 }
 
 // exposureReference is shared by every ExposureChecker Finding rather than a
@@ -48,7 +48,7 @@ func NewExposureChecker(path string, severity Severity) ExposureChecker {
 
 func (c ExposureChecker) Path() string { return c.path }
 
-// Check treats 200/206 as a full-severity hit: the path is directly
+// CheckStatus treats 200/206 as a full-severity hit: the path is directly
 // readable. 403 is still a hit — the server recognized and blocked this
 // specific path rather than treating it like every other nonexistent one, so
 // its existence is confirmed — but one severity step down from 200/206,
@@ -56,7 +56,7 @@ func (c ExposureChecker) Path() string { return c.path }
 // clean and produces no Finding: Scan's baseline probe (see
 // scanExposurePaths) is what makes a non-404 status here trustworthy rather
 // than a false positive from a soft-404/catch-all server.
-func (c ExposureChecker) Check(statusCode int) []Finding {
+func (c ExposureChecker) CheckStatus(statusCode int) []Finding {
 	switch statusCode {
 	case http.StatusOK, http.StatusPartialContent:
 		return []Finding{c.finding(c.severity, fmt.Sprintf("responded %d: the path is directly readable", statusCode))}
@@ -98,12 +98,12 @@ func lowerSeverity(s Severity) Severity {
 // it gets a fixed middle-of-the-road severity rather than guessing.
 const extraExposurePathSeverity = SeverityMedium
 
-// DefaultExposurePaths lists the well-known sensitive paths ExposureChecker
+// DefaultPathCheckers lists the well-known sensitive paths ExposureChecker
 // probes for when the category is enabled: version control metadata,
 // environment files, credential stores, and common backup-file patterns.
 // User configuration can only extend this list (see PathCheckersFor), never
 // replace or disable any of its entries.
-func DefaultExposurePaths() []PathChecker {
+func DefaultPathCheckers() []PathChecker {
 	return []PathChecker{
 		NewExposureChecker(".git/config", SeverityHigh),
 		NewExposureChecker(".git/HEAD", SeverityHigh),
@@ -111,7 +111,7 @@ func DefaultExposurePaths() []PathChecker {
 		NewExposureChecker(".DS_Store", SeverityLow),
 		// .htpasswd holds credential hashes and web.config can hold
 		// connection strings/secrets, so both get the same high severity as
-		// .git/* and .env rather than the DefaultExposurePaths doc
+		// .git/* and .env rather than the DefaultPathCheckers doc
 		// comment's other two categories (low/medium), neither of which
 		// fits a credentials or secrets file.
 		NewExposureChecker(".htpasswd", SeverityHigh),
@@ -124,7 +124,7 @@ func DefaultExposurePaths() []PathChecker {
 }
 
 // PathCheckersFor builds the effective PathChecker set for a scan from the
-// resolved config: enabled turns on DefaultExposurePaths, and extra adds to
+// resolved config: enabled turns on DefaultPathCheckers, and extra adds to
 // it — supplying at least one extra path enables the category on its own,
 // even when enabled is false, since adding a path can't be a silent no-op.
 // A nil/empty result (both enabled is false and extra is empty) tells Scan
@@ -134,7 +134,7 @@ func PathCheckersFor(enabled bool, extra []string) []PathChecker {
 	if !enabled && len(extra) == 0 {
 		return nil
 	}
-	checkers := DefaultExposurePaths()
+	checkers := DefaultPathCheckers()
 	seen := make(map[string]bool, len(checkers))
 	for _, c := range checkers {
 		seen[c.Path()] = true

--- a/internal/scanner/exposure.go
+++ b/internal/scanner/exposure.go
@@ -1,0 +1,150 @@
+package scanner
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// PathChecker is a checker category parallel to Checker (headers) and
+// BodyChecker (body): it declares a path to probe at a target's origin and
+// judges the response's status code, rather than headers or a body already
+// fetched for the plain scan request. Scan issues one dedicated request per
+// configured PathChecker per target — see scanExposurePaths — and only pays
+// for those extra requests when at least one PathChecker is configured,
+// mirroring how BodyChecker's extra body fetch is opt-in.
+type PathChecker interface {
+	// Path is root-relative (no leading slash), resolved against the
+	// target's scheme+host regardless of any path component in the target
+	// URL itself.
+	Path() string
+	// Check judges the probe response's status code, returning no Finding
+	// for anything that isn't a confirmed hit.
+	Check(statusCode int) []Finding
+}
+
+// exposureReference is shared by every ExposureChecker Finding rather than a
+// citation per path: they're all instances of the same underlying testing
+// concern (exposed backup/config/sensitive files), not distinct
+// vulnerability classes.
+const exposureReference = "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Test_for_Backup_and_Unreferenced_Files_or_Applications"
+
+// ExposureChecker is a PathChecker that flags a well-known sensitive path
+// (e.g. .git/config, .env) as exposed when it's reachable at a target's
+// origin. severity is fixed per instance, matching how severity is already
+// fixed per checker instance elsewhere in this package rather than computed
+// per Finding.
+type ExposureChecker struct {
+	path     string
+	severity Severity
+}
+
+// NewExposureChecker builds an ExposureChecker for path at the given
+// severity — the constructor exists because path/severity are unexported, so
+// ExposureChecker's zero value alone can't be configured into a usable
+// checker from outside the package.
+func NewExposureChecker(path string, severity Severity) ExposureChecker {
+	return ExposureChecker{path: path, severity: severity}
+}
+
+func (c ExposureChecker) Path() string { return c.path }
+
+// Check treats 200/206 as a full-severity hit: the path is directly
+// readable. 403 is still a hit — the server recognized and blocked this
+// specific path rather than treating it like every other nonexistent one, so
+// its existence is confirmed — but one severity step down from 200/206,
+// since access is at least blocked. Any other status, in particular 404, is
+// clean and produces no Finding: Scan's baseline probe (see
+// scanExposurePaths) is what makes a non-404 status here trustworthy rather
+// than a false positive from a soft-404/catch-all server.
+func (c ExposureChecker) Check(statusCode int) []Finding {
+	switch statusCode {
+	case http.StatusOK, http.StatusPartialContent:
+		return []Finding{c.finding(c.severity, fmt.Sprintf("responded %d: the path is directly readable", statusCode))}
+	case http.StatusForbidden:
+		return []Finding{c.finding(lowerSeverity(c.severity), "responded 403: the path exists (the server treated it differently from an unrecognized path) but direct access is blocked")}
+	default:
+		return nil
+	}
+}
+
+func (c ExposureChecker) finding(severity Severity, message string) Finding {
+	return Finding{
+		Header:    c.path,
+		Status:    StatusExposed,
+		Severity:  severity,
+		Reference: exposureReference,
+		Message:   message,
+	}
+}
+
+// lowerSeverity steps a severity down one level, floored at low, for
+// ExposureChecker's 403 case: the path's existence is confirmed but access
+// is blocked, so it's never a full-severity hit but also never disappears
+// entirely at the bottom of the scale.
+func lowerSeverity(s Severity) Severity {
+	switch s {
+	case SeverityHigh:
+		return SeverityMedium
+	case SeverityMedium:
+		return SeverityLow
+	default:
+		return SeverityLow
+	}
+}
+
+// extraExposurePathSeverity is the fixed severity assigned to a
+// user-supplied extra path (see PathCheckersFor): there's no way to infer
+// how sensitive an arbitrary user-supplied path is from its name alone, so
+// it gets a fixed middle-of-the-road severity rather than guessing.
+const extraExposurePathSeverity = SeverityMedium
+
+// DefaultExposurePaths lists the well-known sensitive paths ExposureChecker
+// probes for when the category is enabled: version control metadata,
+// environment files, credential stores, and common backup-file patterns.
+// User configuration can only extend this list (see PathCheckersFor), never
+// replace or disable any of its entries.
+func DefaultExposurePaths() []PathChecker {
+	return []PathChecker{
+		NewExposureChecker(".git/config", SeverityHigh),
+		NewExposureChecker(".git/HEAD", SeverityHigh),
+		NewExposureChecker(".env", SeverityHigh),
+		NewExposureChecker(".DS_Store", SeverityLow),
+		// .htpasswd holds credential hashes and web.config can hold
+		// connection strings/secrets, so both get the same high severity as
+		// .git/* and .env rather than the DefaultExposurePaths doc
+		// comment's other two categories (low/medium), neither of which
+		// fits a credentials or secrets file.
+		NewExposureChecker(".htpasswd", SeverityHigh),
+		NewExposureChecker("web.config", SeverityHigh),
+		NewExposureChecker("wp-config.php.bak", SeverityMedium),
+		NewExposureChecker("config.php.bak", SeverityMedium),
+		NewExposureChecker("backup.zip", SeverityMedium),
+		NewExposureChecker("backup.tar.gz", SeverityMedium),
+	}
+}
+
+// PathCheckersFor builds the effective PathChecker set for a scan from the
+// resolved config: enabled turns on DefaultExposurePaths, and extra adds to
+// it — supplying at least one extra path enables the category on its own,
+// even when enabled is false, since adding a path can't be a silent no-op.
+// A nil/empty result (both enabled is false and extra is empty) tells Scan
+// the category is off entirely, so it skips the extra probe requests. An
+// extra path already in the default list is probed once, not twice.
+func PathCheckersFor(enabled bool, extra []string) []PathChecker {
+	if !enabled && len(extra) == 0 {
+		return nil
+	}
+	checkers := DefaultExposurePaths()
+	seen := make(map[string]bool, len(checkers))
+	for _, c := range checkers {
+		seen[c.Path()] = true
+	}
+	for _, path := range extra {
+		if seen[path] {
+			continue
+		}
+		seen[path] = true
+		checkers = append(checkers, NewExposureChecker(path, extraExposurePathSeverity))
+	}
+	return checkers
+}

--- a/internal/scanner/exposure_test.go
+++ b/internal/scanner/exposure_test.go
@@ -1,0 +1,165 @@
+package scanner_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/PhyberApex/mamori/internal/scanner"
+)
+
+func TestExposureCheckerHitStatusesProduceExposedFinding(t *testing.T) {
+	tests := []struct {
+		name         string
+		statusCode   int
+		wantSeverity scanner.Severity
+	}{
+		{"200 is a full-severity hit", http.StatusOK, scanner.SeverityHigh},
+		{"206 is a full-severity hit", http.StatusPartialContent, scanner.SeverityHigh},
+		{"403 is a hit at a lower severity", http.StatusForbidden, scanner.SeverityMedium},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := scanner.NewExposureChecker(".env", scanner.SeverityHigh)
+			findings := checker.Check(tt.statusCode)
+			if len(findings) != 1 {
+				t.Fatalf("Check(%d) returned %d findings, want 1", tt.statusCode, len(findings))
+			}
+			f := findings[0]
+			if f.Status != scanner.StatusExposed {
+				t.Errorf("Status = %q, want %q", f.Status, scanner.StatusExposed)
+			}
+			if f.Severity != tt.wantSeverity {
+				t.Errorf("Severity = %q, want %q", f.Severity, tt.wantSeverity)
+			}
+			if f.Header != ".env" {
+				t.Errorf("Header = %q, want the probed path %q", f.Header, ".env")
+			}
+			if f.Reference == "" {
+				t.Error("Reference is empty, want a docs URL")
+			}
+			if f.Message == "" {
+				t.Error("Message is empty, want an explanation of the hit")
+			}
+		})
+	}
+}
+
+func TestExposureCheckerNonHitStatusesProduceNoFinding(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusInternalServerError, http.StatusMovedPermanently} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			checker := scanner.NewExposureChecker(".env", scanner.SeverityHigh)
+			if findings := checker.Check(status); len(findings) != 0 {
+				t.Errorf("Check(%d) returned %d findings, want 0", status, len(findings))
+			}
+		})
+	}
+}
+
+func TestExposureChecker403SeverityStepsDownFromEachLevel(t *testing.T) {
+	tests := []struct {
+		configured scanner.Severity
+		want403    scanner.Severity
+	}{
+		{scanner.SeverityHigh, scanner.SeverityMedium},
+		{scanner.SeverityMedium, scanner.SeverityLow},
+		{scanner.SeverityLow, scanner.SeverityLow},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.configured), func(t *testing.T) {
+			checker := scanner.NewExposureChecker("x", tt.configured)
+			findings := checker.Check(http.StatusForbidden)
+			if len(findings) != 1 {
+				t.Fatalf("Check(403) returned %d findings, want 1", len(findings))
+			}
+			if findings[0].Severity != tt.want403 {
+				t.Errorf("403 severity for configured %q = %q, want %q", tt.configured, findings[0].Severity, tt.want403)
+			}
+			hit200 := checker.Check(http.StatusOK)
+			if hit200[0].Severity != tt.configured {
+				t.Errorf("200 severity = %q, want configured severity %q unchanged", hit200[0].Severity, tt.configured)
+			}
+		})
+	}
+}
+
+func TestDefaultExposurePathsCoversTheTenDocumentedPaths(t *testing.T) {
+	want := []string{
+		".git/config", ".git/HEAD", ".env", ".DS_Store", ".htpasswd",
+		"web.config", "wp-config.php.bak", "config.php.bak", "backup.zip", "backup.tar.gz",
+	}
+	checkers := scanner.DefaultExposurePaths()
+	if len(checkers) != len(want) {
+		t.Fatalf("DefaultExposurePaths() returned %d checkers, want %d", len(checkers), len(want))
+	}
+	got := make(map[string]bool, len(checkers))
+	for _, c := range checkers {
+		got[c.Path()] = true
+	}
+	for _, path := range want {
+		if !got[path] {
+			t.Errorf("DefaultExposurePaths() is missing %q", path)
+		}
+	}
+}
+
+func TestPathCheckersForDisabledWithNoExtraPathsReturnsNil(t *testing.T) {
+	if got := scanner.PathCheckersFor(false, nil); got != nil {
+		t.Errorf("PathCheckersFor(false, nil) = %v, want nil (category off)", got)
+	}
+}
+
+func TestPathCheckersForEnabledReturnsDefaultList(t *testing.T) {
+	checkers := scanner.PathCheckersFor(true, nil)
+	if len(checkers) != len(scanner.DefaultExposurePaths()) {
+		t.Errorf("PathCheckersFor(true, nil) returned %d checkers, want %d (the default list)", len(checkers), len(scanner.DefaultExposurePaths()))
+	}
+}
+
+func TestPathCheckersForExtraPathAloneEnablesCategory(t *testing.T) {
+	checkers := scanner.PathCheckersFor(false, []string{"debug.log"})
+	if checkers == nil {
+		t.Fatal("PathCheckersFor(false, [\"debug.log\"]) = nil, want the category enabled by the extra path alone")
+	}
+	want := len(scanner.DefaultExposurePaths()) + 1
+	if len(checkers) != want {
+		t.Errorf("PathCheckersFor(false, [\"debug.log\"]) returned %d checkers, want %d (default list + 1 extra)", len(checkers), want)
+	}
+	found := false
+	for _, c := range checkers {
+		if c.Path() == "debug.log" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("extra path \"debug.log\" is missing from the effective checker set")
+	}
+}
+
+func TestPathCheckersForExtraPathAddsToDefaultListNeverReplacesIt(t *testing.T) {
+	checkers := scanner.PathCheckersFor(true, []string{"debug.log"})
+	paths := map[string]bool{}
+	for _, c := range checkers {
+		paths[c.Path()] = true
+	}
+	for _, defaultPath := range []string{".git/config", ".env"} {
+		if !paths[defaultPath] {
+			t.Errorf("default path %q is missing when extra paths are configured, want it kept", defaultPath)
+		}
+	}
+	if !paths["debug.log"] {
+		t.Error("extra path \"debug.log\" is missing")
+	}
+}
+
+func TestPathCheckersForExtraPathDuplicatingADefaultIsProbedOnce(t *testing.T) {
+	checkers := scanner.PathCheckersFor(true, []string{".env"})
+	count := 0
+	for _, c := range checkers {
+		if c.Path() == ".env" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("%q appears %d times in the effective checker set, want 1 (extra path already in the default list)", ".env", count)
+	}
+}

--- a/internal/scanner/exposure_test.go
+++ b/internal/scanner/exposure_test.go
@@ -20,9 +20,9 @@ func TestExposureCheckerHitStatusesProduceExposedFinding(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			checker := scanner.NewExposureChecker(".env", scanner.SeverityHigh)
-			findings := checker.Check(tt.statusCode)
+			findings := checker.CheckStatus(tt.statusCode)
 			if len(findings) != 1 {
-				t.Fatalf("Check(%d) returned %d findings, want 1", tt.statusCode, len(findings))
+				t.Fatalf("CheckStatus(%d) returned %d findings, want 1", tt.statusCode, len(findings))
 			}
 			f := findings[0]
 			if f.Status != scanner.StatusExposed {
@@ -48,8 +48,8 @@ func TestExposureCheckerNonHitStatusesProduceNoFinding(t *testing.T) {
 	for _, status := range []int{http.StatusNotFound, http.StatusInternalServerError, http.StatusMovedPermanently} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			checker := scanner.NewExposureChecker(".env", scanner.SeverityHigh)
-			if findings := checker.Check(status); len(findings) != 0 {
-				t.Errorf("Check(%d) returned %d findings, want 0", status, len(findings))
+			if findings := checker.CheckStatus(status); len(findings) != 0 {
+				t.Errorf("CheckStatus(%d) returned %d findings, want 0", status, len(findings))
 			}
 		})
 	}
@@ -67,14 +67,14 @@ func TestExposureChecker403SeverityStepsDownFromEachLevel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(string(tt.configured), func(t *testing.T) {
 			checker := scanner.NewExposureChecker("x", tt.configured)
-			findings := checker.Check(http.StatusForbidden)
+			findings := checker.CheckStatus(http.StatusForbidden)
 			if len(findings) != 1 {
-				t.Fatalf("Check(403) returned %d findings, want 1", len(findings))
+				t.Fatalf("CheckStatus(403) returned %d findings, want 1", len(findings))
 			}
 			if findings[0].Severity != tt.want403 {
 				t.Errorf("403 severity for configured %q = %q, want %q", tt.configured, findings[0].Severity, tt.want403)
 			}
-			hit200 := checker.Check(http.StatusOK)
+			hit200 := checker.CheckStatus(http.StatusOK)
 			if hit200[0].Severity != tt.configured {
 				t.Errorf("200 severity = %q, want configured severity %q unchanged", hit200[0].Severity, tt.configured)
 			}
@@ -82,14 +82,14 @@ func TestExposureChecker403SeverityStepsDownFromEachLevel(t *testing.T) {
 	}
 }
 
-func TestDefaultExposurePathsCoversTheTenDocumentedPaths(t *testing.T) {
+func TestDefaultPathCheckersCoversTheTenDocumentedPaths(t *testing.T) {
 	want := []string{
 		".git/config", ".git/HEAD", ".env", ".DS_Store", ".htpasswd",
 		"web.config", "wp-config.php.bak", "config.php.bak", "backup.zip", "backup.tar.gz",
 	}
-	checkers := scanner.DefaultExposurePaths()
+	checkers := scanner.DefaultPathCheckers()
 	if len(checkers) != len(want) {
-		t.Fatalf("DefaultExposurePaths() returned %d checkers, want %d", len(checkers), len(want))
+		t.Fatalf("DefaultPathCheckers() returned %d checkers, want %d", len(checkers), len(want))
 	}
 	got := make(map[string]bool, len(checkers))
 	for _, c := range checkers {
@@ -97,7 +97,7 @@ func TestDefaultExposurePathsCoversTheTenDocumentedPaths(t *testing.T) {
 	}
 	for _, path := range want {
 		if !got[path] {
-			t.Errorf("DefaultExposurePaths() is missing %q", path)
+			t.Errorf("DefaultPathCheckers() is missing %q", path)
 		}
 	}
 }
@@ -110,8 +110,8 @@ func TestPathCheckersForDisabledWithNoExtraPathsReturnsNil(t *testing.T) {
 
 func TestPathCheckersForEnabledReturnsDefaultList(t *testing.T) {
 	checkers := scanner.PathCheckersFor(true, nil)
-	if len(checkers) != len(scanner.DefaultExposurePaths()) {
-		t.Errorf("PathCheckersFor(true, nil) returned %d checkers, want %d (the default list)", len(checkers), len(scanner.DefaultExposurePaths()))
+	if len(checkers) != len(scanner.DefaultPathCheckers()) {
+		t.Errorf("PathCheckersFor(true, nil) returned %d checkers, want %d (the default list)", len(checkers), len(scanner.DefaultPathCheckers()))
 	}
 }
 
@@ -120,7 +120,7 @@ func TestPathCheckersForExtraPathAloneEnablesCategory(t *testing.T) {
 	if checkers == nil {
 		t.Fatal("PathCheckersFor(false, [\"debug.log\"]) = nil, want the category enabled by the extra path alone")
 	}
-	want := len(scanner.DefaultExposurePaths()) + 1
+	want := len(scanner.DefaultPathCheckers()) + 1
 	if len(checkers) != want {
 		t.Errorf("PathCheckersFor(false, [\"debug.log\"]) returned %d checkers, want %d (default list + 1 extra)", len(checkers), want)
 	}

--- a/internal/scanner/finding.go
+++ b/internal/scanner/finding.go
@@ -11,8 +11,14 @@ const (
 	// no-op, so it doesn't provide the protection the header exists for.
 	// Kept distinct from StatusPass so scans don't silently treat a
 	// self-defeating value (e.g. max-age=0) as a clean bill of health.
-	StatusWeak  Status = "weak"
-	StatusError Status = "error"
+	StatusWeak Status = "weak"
+	// StatusExposed marks a PathChecker Finding whose probed path was
+	// confirmed reachable (a 200/206/403 response). Kept distinct from
+	// Missing/Weak, which both describe absent-or-defective *header* state
+	// on the target URL itself — Exposed instead describes a path beyond the
+	// target URL that shouldn't be reachable at all.
+	StatusExposed Status = "exposed"
+	StatusError   Status = "error"
 )
 
 type Severity string
@@ -75,7 +81,12 @@ func (s *Severity) Set(v string) error {
 // downstream jq pipelines. Without a tag, encoding/json would emit the
 // exported (capitalized) field name instead.
 type Finding struct {
-	URL       string   `json:"url"`
+	URL string `json:"url"`
+	// Header names the specific thing a Finding reports on: a header name
+	// for a Checker/BodyChecker Finding, or the probed path (e.g.
+	// ".git/config") for a PathChecker Finding. Reused rather than adding a
+	// path-specific field so every existing reporter renders both kinds
+	// with no reporter-specific changes.
 	Header    string   `json:"header"`
 	Status    Status   `json:"status"`
 	Severity  Severity `json:"severity"`
@@ -98,8 +109,8 @@ type Finding struct {
 // severity or Status, since that's the entire point of suppressing it.
 // Otherwise a StatusError always fails, regardless of threshold, since a
 // scan that couldn't complete shouldn't silently report success; a
-// Missing/Weak finding fails once its severity reaches threshold; a Pass
-// never fails.
+// Missing/Weak/Exposed finding fails once its severity reaches threshold; a
+// Pass never fails.
 func (f Finding) Fails(threshold Severity) bool {
 	if threshold == "" {
 		return false
@@ -110,7 +121,7 @@ func (f Finding) Fails(threshold Severity) bool {
 	if f.Status == StatusError {
 		return true
 	}
-	if f.Status != StatusMissing && f.Status != StatusWeak {
+	if f.Status != StatusMissing && f.Status != StatusWeak && f.Status != StatusExposed {
 		return false
 	}
 	return f.Severity.AtLeast(threshold)

--- a/internal/scanner/finding.go
+++ b/internal/scanner/finding.go
@@ -85,8 +85,10 @@ type Finding struct {
 	// Header names the specific thing a Finding reports on: a header name
 	// for a Checker/BodyChecker Finding, or the probed path (e.g.
 	// ".git/config") for a PathChecker Finding. Reused rather than adding a
-	// path-specific field so every existing reporter renders both kinds
-	// with no reporter-specific changes.
+	// path-specific field so every reporter renders both kinds through the
+	// same field, needing only the same kind of extra per-Status branch
+	// StatusError already required (see statusTag, sarifRuleAndResult) —
+	// not a whole new code path.
 	Header    string   `json:"header"`
 	Status    Status   `json:"status"`
 	Severity  Severity `json:"severity"`

--- a/internal/scanner/finding_test.go
+++ b/internal/scanner/finding_test.go
@@ -131,6 +131,18 @@ func TestFindingFails(t *testing.T) {
 			want:      true,
 		},
 		{
+			name:      "exposed at threshold fails",
+			finding:   scanner.Finding{Status: scanner.StatusExposed, Severity: scanner.SeverityHigh},
+			threshold: scanner.SeverityHigh,
+			want:      true,
+		},
+		{
+			name:      "exposed below threshold does not fail",
+			finding:   scanner.Finding{Status: scanner.StatusExposed, Severity: scanner.SeverityLow},
+			threshold: scanner.SeverityHigh,
+			want:      false,
+		},
+		{
 			name:      "error always fails regardless of severity",
 			finding:   scanner.Finding{Status: scanner.StatusError, Severity: scanner.SeverityLow},
 			threshold: scanner.SeverityHigh,

--- a/internal/scanner/report.go
+++ b/internal/scanner/report.go
@@ -39,9 +39,9 @@ func colorize(color, s string) string {
 	return color + s + ansiReset
 }
 
-// statusTag picks the color from severity for missing/weak headers so a
-// high-severity finding reads as urgent (red) while lower severities stay a
-// warning yellow.
+// statusTag picks the color from severity for missing/weak/exposed findings
+// so a high-severity finding reads as urgent (red) while lower severities
+// stay a warning yellow.
 func statusTag(f Finding) string {
 	switch f.Status {
 	case StatusPass:
@@ -53,8 +53,11 @@ func statusTag(f Finding) string {
 	if f.Severity == SeverityHigh {
 		color = ansiRed
 	}
-	if f.Status == StatusWeak {
+	switch f.Status {
+	case StatusWeak:
 		return colorize(color, "WEAK")
+	case StatusExposed:
+		return colorize(color, "EXPOSED")
 	}
 	return colorize(color, "MISSING")
 }
@@ -81,7 +84,7 @@ func (TerminalReporter) Report(findings []Finding, w io.Writer) error {
 				line = fmt.Sprintf("  [%s] %s", statusTag(f), f.Message)
 			} else {
 				line = fmt.Sprintf("  [%s] %s (%s)", statusTag(f), f.Header, f.Severity)
-				if f.Status == StatusWeak && f.Message != "" {
+				if (f.Status == StatusWeak || f.Status == StatusExposed) && f.Message != "" {
 					line += ": " + f.Message
 				}
 				if f.Status != StatusPass && f.Reference != "" {

--- a/internal/scanner/report_test.go
+++ b/internal/scanner/report_test.go
@@ -92,6 +92,36 @@ func TestTerminalReporterShowsWeakMessage(t *testing.T) {
 	}
 }
 
+func TestTerminalReporterShowsExposedFinding(t *testing.T) {
+	findings := []scanner.Finding{
+		{
+			URL:       "https://a.example",
+			Header:    ".git/config",
+			Status:    scanner.StatusExposed,
+			Severity:  scanner.SeverityHigh,
+			Message:   "responded 200: the path is directly readable",
+			Reference: "https://owasp.example/exposure",
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := (scanner.TerminalReporter{}).Report(findings, &buf); err != nil {
+		t.Fatalf("Report() returned error: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{"EXPOSED", ".git/config", "responded 200: the path is directly readable", "https://owasp.example/exposure"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\noutput:\n%s", want, out)
+		}
+	}
+
+	//nolint:gosec // G101 false positive: ANSI color assertion, not credentials
+	if !strings.Contains(out, "\x1b[31mEXPOSED\x1b[0m") {
+		t.Errorf("EXPOSED tag for high-severity finding is not red\noutput:\n%q", out)
+	}
+}
+
 func TestTerminalReporterShowsErrorMessage(t *testing.T) {
 	findings := []scanner.Finding{
 		{

--- a/internal/scanner/sarif.go
+++ b/internal/scanner/sarif.go
@@ -121,14 +121,26 @@ func (SarifReporter) Report(findings []Finding, w io.Writer) error {
 // scan never got far enough to check headers — so they're branched on once
 // here rather than in each field separately: a fixed "scan-error" rule, and
 // a level of "error" since a failed scan is not merely a warning.
+// StatusExposed findings reuse Header for a probed path rather than a header
+// name (see Finding.Header), so they get their own wording rather than the
+// "%s header is %s" phrasing every other Status shares.
 func sarifRuleAndResult(f Finding) (sarifRule, sarifResult) {
 	var ruleID, description, message, level string
-	if f.Status == StatusError {
+	switch f.Status {
+	case StatusError:
 		ruleID = "scan-error"
 		description = "The scan could not complete for this target."
 		message = f.Message
 		level = "error"
-	} else {
+	case StatusExposed:
+		ruleID = f.Header
+		description = fmt.Sprintf("Checks whether %s is exposed.", f.Header)
+		message = fmt.Sprintf("%s is exposed", f.Header)
+		if f.Message != "" {
+			message += ": " + f.Message
+		}
+		level = sarifLevel(f.Severity)
+	default:
 		ruleID = f.Header
 		description = fmt.Sprintf("Checks the %s response header.", f.Header)
 		message = fmt.Sprintf("%s header is %s", f.Header, f.Status)

--- a/internal/scanner/sarif_test.go
+++ b/internal/scanner/sarif_test.go
@@ -3,6 +3,7 @@ package scanner_test
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/PhyberApex/mamori/internal/scanner"
@@ -108,6 +109,49 @@ func TestSarifReporterMapsSeverityToLevel(t *testing.T) {
 		if r.RuleID == "scan-error" && r.Message.Text != "context deadline exceeded" {
 			t.Errorf("scan-error message = %q, want the scan error text", r.Message.Text)
 		}
+	}
+}
+
+func TestSarifReporterRendersExposedFindingWithoutHeaderWording(t *testing.T) {
+	findings := []scanner.Finding{
+		{URL: "https://a.example", Header: ".env", Status: scanner.StatusExposed, Severity: scanner.SeverityHigh, Message: "responded 200: the path is directly readable"},
+	}
+
+	var buf bytes.Buffer
+	if err := (scanner.SarifReporter{}).Report(findings, &buf); err != nil {
+		t.Fatalf("Report() returned error: %v", err)
+	}
+
+	var doc struct {
+		Runs []struct {
+			Results []struct {
+				RuleID  string `json:"ruleId"`
+				Level   string `json:"level"`
+				Message struct {
+					Text string `json:"text"`
+				} `json:"message"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, buf.String())
+	}
+
+	if len(doc.Runs[0].Results) != 1 {
+		t.Fatalf("got %d results, want 1", len(doc.Runs[0].Results))
+	}
+	result := doc.Runs[0].Results[0]
+	if result.RuleID != ".env" {
+		t.Errorf("ruleId = %q, want %q", result.RuleID, ".env")
+	}
+	if result.Level != "error" {
+		t.Errorf("level = %q, want %q (high severity)", result.Level, "error")
+	}
+	if strings.Contains(result.Message.Text, "header") {
+		t.Errorf("message = %q, want no \"header\" wording for a path-exposure finding", result.Message.Text)
+	}
+	if !strings.Contains(result.Message.Text, ".env") || !strings.Contains(result.Message.Text, "responded 200") {
+		t.Errorf("message = %q, want it to name the path and include the finding's own message", result.Message.Text)
 	}
 }
 

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -139,7 +139,7 @@ func scanExposurePaths(ctx context.Context, client *http.Client, pathCheckers []
 			if err != nil {
 				return
 			}
-			fs := pc.Check(status)
+			fs := pc.CheckStatus(status)
 			if len(fs) == 0 {
 				return
 			}

--- a/internal/scanner/scan.go
+++ b/internal/scanner/scan.go
@@ -2,8 +2,12 @@ package scanner
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 )
 
@@ -11,7 +15,7 @@ import (
 // target becomes an error finding instead of aborting the scan, so every
 // target is accounted for in the report. headers, if non-nil, is applied to
 // every outgoing request (e.g. for endpoints that require auth).
-func Scan(ctx context.Context, client *http.Client, checkers []Checker, bodyCheckers []BodyChecker, urls []string, workers int, headers http.Header) []Finding {
+func Scan(ctx context.Context, client *http.Client, checkers []Checker, bodyCheckers []BodyChecker, pathCheckers []PathChecker, urls []string, workers int, headers http.Header) []Finding {
 	jobs := make(chan int)
 	// Each worker writes only to its own job's index, so the slice needs no
 	// mutex: distinct goroutines never touch the same element, and wg.Wait()
@@ -28,7 +32,7 @@ func Scan(ctx context.Context, client *http.Client, checkers []Checker, bodyChec
 			// Ranging over a channel keeps receiving until it is closed,
 			// which is how each worker knows there is no more work.
 			for i := range jobs {
-				perTarget[i] = scanTarget(ctx, client, checkers, bodyCheckers, urls[i], headers)
+				perTarget[i] = scanTarget(ctx, client, checkers, bodyCheckers, pathCheckers, urls[i], headers)
 			}
 		}()
 	}
@@ -50,7 +54,7 @@ func Scan(ctx context.Context, client *http.Client, checkers []Checker, bodyChec
 // scanTarget only pays for a body download when a BodyChecker actually needs
 // one: with none configured it keeps the HEAD-preferring fetchHeaders path,
 // same as before body checks existed.
-func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, bodyCheckers []BodyChecker, url string, reqHeaders http.Header) []Finding {
+func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, bodyCheckers []BodyChecker, pathCheckers []PathChecker, url string, reqHeaders http.Header) []Finding {
 	var respHeaders http.Header
 	var bodyFindings []Finding
 	var err error
@@ -82,10 +86,109 @@ func scanTarget(ctx context.Context, client *http.Client, checkers []Checker, bo
 		}
 	}
 
+	// Only pay for the exposure-check requests when at least one PathChecker
+	// is configured, same opt-in-cost pattern as bodyCheckers/originBased
+	// above.
+	if len(pathCheckers) > 0 {
+		findings = append(findings, scanExposurePaths(ctx, client, pathCheckers, url, reqHeaders)...)
+	}
+
 	for i := range findings {
 		findings[i].URL = url
 	}
 	return findings
+}
+
+// scanExposurePaths runs the sensitive-path exposure check for one target.
+// It first issues a probe to a randomized, deliberately-nonexistent path at
+// the target's origin: if that doesn't come back 404, the target is a
+// soft-404/catch-all server (or the probe itself failed), which would make
+// every configured path below look exposed regardless of whether it
+// actually is — so this returns exactly one StatusError Finding noting the
+// check was skipped, and probes none of the configured paths. Otherwise
+// every configured path is probed concurrently, root-relative to the
+// target's origin regardless of any path component in targetURL itself —
+// mamori issues no other requests per target for this check, so there's no
+// staggering to do.
+func scanExposurePaths(ctx context.Context, client *http.Client, pathCheckers []PathChecker, targetURL string, reqHeaders http.Header) []Finding {
+	origin, err := targetOrigin(targetURL)
+	if err != nil {
+		return nil
+	}
+
+	baselineStatus, err := probePathStatus(ctx, client, origin, randomExposureProbePath(), reqHeaders)
+	if err != nil || baselineStatus != http.StatusNotFound {
+		return []Finding{{
+			Status:  StatusError,
+			Message: "sensitive-path exposure check skipped: target did not return 404 for a random nonexistent path, so its responses can't be trusted to tell an exposed path from a missing one",
+		}}
+	}
+
+	var mu sync.Mutex
+	var findings []Finding
+	var wg sync.WaitGroup
+	for _, pc := range pathCheckers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// A single path's probe failing (as opposed to the baseline
+			// probe above) is skipped rather than turned into a Finding,
+			// the same "don't blank out everything else on one extra
+			// request failing" treatment fetchOriginProbeHeaders gets.
+			status, err := probePathStatus(ctx, client, origin, pc.Path(), reqHeaders)
+			if err != nil {
+				return
+			}
+			fs := pc.Check(status)
+			if len(fs) == 0 {
+				return
+			}
+			mu.Lock()
+			findings = append(findings, fs...)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	return findings
+}
+
+// targetOrigin returns targetURL's scheme+host, discarding any path/query:
+// exposure paths are always probed root-relative to the origin, never
+// relative to whatever path component the target URL itself has.
+func targetOrigin(targetURL string) (string, error) {
+	u, err := url.Parse(targetURL)
+	if err != nil {
+		return "", err
+	}
+	return u.Scheme + "://" + u.Host, nil
+}
+
+// probePathStatus issues a GET for path at origin and returns the response
+// status code. GET rather than the plain scan's HEAD-then-fallback: some of
+// the paths this check probes (e.g. .htpasswd) are handled by servers that
+// only recognize GET, and this check only needs a status code, so there's no
+// benefit to a second request the way the HEAD/GET fallback avoids one for
+// header inspection.
+func probePathStatus(ctx context.Context, client *http.Client, origin, path string, reqHeaders http.Header) (int, error) {
+	target := origin + "/" + strings.TrimPrefix(path, "/")
+	_, status, err := doRequest(ctx, client, http.MethodGet, target, reqHeaders, "")
+	return status, err
+}
+
+// randomExposureProbePath returns a root-relative path that's exceedingly
+// unlikely to exist on a real target and different on every call, so a
+// target can't special-case a fixed probe string to defeat
+// scanExposurePaths' baseline reliability check.
+func randomExposureProbePath() string {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// crypto/rand.Read only fails if the OS entropy source is
+		// unavailable, in which case the process has bigger problems than
+		// this probe. A fixed fallback keeps the baseline check functional
+		// (if no longer unguessable) rather than panicking mid-scan.
+		return "mamori-exposure-probe-fallback"
+	}
+	return "mamori-exposure-probe-" + hex.EncodeToString(buf[:])
 }
 
 // splitOriginProbers separates checkers that judge the plain scan request

--- a/internal/scanner/scan_test.go
+++ b/internal/scanner/scan_test.go
@@ -29,7 +29,7 @@ func scanOne(t *testing.T, handler http.Handler) []scanner.Finding {
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, []string{srv.URL}, 1, nil)
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, nil, []string{srv.URL}, 1, nil)
 	if len(findings) != 10 {
 		t.Fatalf("Scan() returned %d findings, want 10", len(findings))
 	}
@@ -84,7 +84,7 @@ func TestScanSkipsBodyFetchWhenNoBodyCheckersConfigured(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, []string{srv.URL}, 1, nil)
+	scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, nil, []string{srv.URL}, 1, nil)
 	if gotMethod != http.MethodHead {
 		t.Errorf("request method = %q, want %q (HEAD should be tried first when no body checkers are configured)", gotMethod, http.MethodHead)
 	}
@@ -96,7 +96,7 @@ func TestScanRunsBodyCheckersWhenConfigured(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	findings := scanner.Scan(t.Context(), srv.Client(), nil, scanner.DefaultBodyCheckers(), []string{srv.URL}, 1, nil)
+	findings := scanner.Scan(t.Context(), srv.Client(), nil, scanner.DefaultBodyCheckers(), nil, []string{srv.URL}, 1, nil)
 	if len(findings) != 1 {
 		t.Fatalf("Scan() returned %d findings, want 1", len(findings))
 	}
@@ -115,7 +115,7 @@ func TestScanFlagsMixedContentOnHTTPSTarget(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	findings := scanner.Scan(t.Context(), srv.Client(), nil, scanner.DefaultBodyCheckers(), []string{srv.URL}, 1, nil)
+	findings := scanner.Scan(t.Context(), srv.Client(), nil, scanner.DefaultBodyCheckers(), nil, []string{srv.URL}, 1, nil)
 	if len(findings) != 1 {
 		t.Fatalf("Scan() returned %d findings, want 1: %+v", len(findings), findings)
 	}
@@ -135,7 +135,7 @@ func TestScanCombinesHeaderAndBodyCheckerFindings(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	findings := scanner.Scan(t.Context(), srv.Client(), []scanner.Checker{scanner.ContentTypeOptionsChecker{}}, scanner.DefaultBodyCheckers(), []string{srv.URL}, 1, nil)
+	findings := scanner.Scan(t.Context(), srv.Client(), []scanner.Checker{scanner.ContentTypeOptionsChecker{}}, scanner.DefaultBodyCheckers(), nil, []string{srv.URL}, 1, nil)
 	if len(findings) != 2 {
 		t.Fatalf("Scan() returned %d findings, want 2 (1 header + 1 body)", len(findings))
 	}
@@ -152,7 +152,7 @@ func TestScanCoversMultipleURLs(t *testing.T) {
 	srvB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	t.Cleanup(srvB.Close)
 
-	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), nil, []string{srvA.URL, srvB.URL}, 2, nil)
+	findings := scanner.Scan(t.Context(), srvA.Client(), scanner.DefaultCheckers(), nil, nil, []string{srvA.URL, srvB.URL}, 2, nil)
 	if len(findings) != 20 {
 		t.Fatalf("Scan() returned %d findings, want 20 (10 per URL)", len(findings))
 	}
@@ -163,7 +163,7 @@ func TestScanUnreachableTargetYieldsErrorFinding(t *testing.T) {
 	unreachable := srv.URL
 	srv.Close()
 
-	findings := scanner.Scan(t.Context(), http.DefaultClient, scanner.DefaultCheckers(), nil, []string{unreachable}, 1, nil)
+	findings := scanner.Scan(t.Context(), http.DefaultClient, scanner.DefaultCheckers(), nil, nil, []string{unreachable}, 1, nil)
 	if len(findings) != 1 {
 		t.Fatalf("Scan() returned %d findings, want 1 error finding", len(findings))
 	}
@@ -190,7 +190,7 @@ func TestScanServerTimeoutYieldsErrorFinding(t *testing.T) {
 	})
 
 	client := &http.Client{Timeout: 50 * time.Millisecond}
-	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), nil, []string{srv.URL}, 1, nil)
+	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), nil, nil, []string{srv.URL}, 1, nil)
 	if len(findings) != 1 {
 		t.Fatalf("Scan() returned %d findings, want 1 error finding", len(findings))
 	}
@@ -210,7 +210,7 @@ func TestScanReportsAllTargetsDespiteFailures(t *testing.T) {
 	deadURL := dead.URL
 	dead.Close()
 
-	findings := scanner.Scan(t.Context(), http.DefaultClient, scanner.DefaultCheckers(), nil, []string{deadURL, healthy.URL}, 2, nil)
+	findings := scanner.Scan(t.Context(), http.DefaultClient, scanner.DefaultCheckers(), nil, nil, []string{deadURL, healthy.URL}, 2, nil)
 
 	byURL := map[string][]scanner.Finding{}
 	for _, f := range findings {
@@ -242,7 +242,7 @@ func TestScanRunsTargetsConcurrently(t *testing.T) {
 
 	client := &http.Client{Timeout: 5 * time.Second}
 	urls := []string{srv.URL + "/a", srv.URL + "/b", srv.URL + "/c"}
-	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), nil, urls, targets, nil)
+	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), nil, nil, urls, targets, nil)
 
 	assertAllStatus(t, findings, scanner.StatusMissing)
 	if len(findings) != targets*10 {
@@ -273,7 +273,7 @@ func TestScanBoundsConcurrencyToPoolSize(t *testing.T) {
 	for i := range urls {
 		urls[i] = srv.URL + "/" + string(rune('a'+i))
 	}
-	scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, urls, workers, nil)
+	scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, nil, urls, workers, nil)
 
 	if p := peak.Load(); p > workers {
 		t.Errorf("peak concurrent requests = %d, want at most %d", p, workers)
@@ -289,7 +289,7 @@ func TestScanSendsOriginProbeAndFlagsReflectedCORSWithCredentials(t *testing.T) 
 	}))
 	t.Cleanup(srv.Close)
 
-	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, []string{srv.URL}, 1, nil)
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, nil, []string{srv.URL}, 1, nil)
 
 	var corsFindings []scanner.Finding
 	for _, f := range findings {
@@ -335,7 +335,7 @@ func TestScanSkipsFailedProbeRatherThanErroringTarget(t *testing.T) {
 	})
 
 	client := &http.Client{Timeout: 50 * time.Millisecond}
-	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), nil, []string{srv.URL}, 1, nil)
+	findings := scanner.Scan(t.Context(), client, scanner.DefaultCheckers(), nil, nil, []string{srv.URL}, 1, nil)
 
 	if len(findings) == 0 {
 		t.Fatal("Scan() returned no findings, want the plain request's findings despite the probe request failing")
@@ -352,7 +352,7 @@ func TestScanPreservesTargetOrder(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	urls := []string{srv.URL + "/a", srv.URL + "/b", srv.URL + "/c"}
-	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, urls, 3, nil)
+	findings := scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, nil, urls, 3, nil)
 
 	var seen []string
 	for _, f := range findings {
@@ -381,7 +381,7 @@ func TestScanAppliesCustomHeadersToRequests(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("Authorization", "Bearer xyz")
 	headers.Set("Cookie", "session=abc")
-	scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, []string{srv.URL}, 1, headers)
+	scanner.Scan(t.Context(), srv.Client(), scanner.DefaultCheckers(), nil, nil, []string{srv.URL}, 1, headers)
 
 	if gotAuth != "Bearer xyz" {
 		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer xyz")
@@ -400,9 +400,243 @@ func TestScanAppliesCustomHeadersWhenFetchingBody(t *testing.T) {
 
 	headers := http.Header{}
 	headers.Set("Authorization", "Bearer xyz")
-	scanner.Scan(t.Context(), srv.Client(), nil, scanner.DefaultBodyCheckers(), []string{srv.URL}, 1, headers)
+	scanner.Scan(t.Context(), srv.Client(), nil, scanner.DefaultBodyCheckers(), nil, []string{srv.URL}, 1, headers)
 
 	if gotAuth != "Bearer xyz" {
 		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer xyz")
+	}
+}
+
+func TestScanIssuesNoExposureRequestsWhenNoPathCheckersConfigured(t *testing.T) {
+	var count int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&count, 1)
+	}))
+	t.Cleanup(srv.Close)
+
+	// checkers is nil, not DefaultCheckers(): CORSChecker is an OriginProber
+	// and would add its own probe request, muddying a count that's meant to
+	// isolate exposure-check requests specifically.
+	scanner.Scan(t.Context(), srv.Client(), nil, nil, nil, []string{srv.URL}, 1, nil)
+
+	if got := atomic.LoadInt32(&count); got != 1 {
+		t.Errorf("server received %d requests, want 1 (only the plain scan request; no exposure probes when no PathChecker is configured)", got)
+	}
+}
+
+func TestScanConfiguredPathHitsProduceExposedFindings(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.env":
+			w.WriteHeader(http.StatusOK)
+		case "/backup.zip":
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.Scan(t.Context(), srv.Client(), nil, nil, scanner.PathCheckersFor(true, nil), []string{srv.URL}, 1, nil)
+
+	byPath := map[string]scanner.Finding{}
+	for _, f := range findings {
+		if f.Status != scanner.StatusExposed {
+			t.Errorf("unexpected non-exposed finding: %+v", f)
+			continue
+		}
+		byPath[f.Header] = f
+	}
+	if len(byPath) != 2 {
+		t.Fatalf("got %d exposed findings, want 2 (.env and backup.zip; every other default path returned 404): %+v", len(byPath), findings)
+	}
+	if env := byPath[".env"]; env.Severity != scanner.SeverityHigh {
+		t.Errorf(".env severity = %q, want %q (200 hit at its configured severity)", env.Severity, scanner.SeverityHigh)
+	}
+	if bak := byPath["backup.zip"]; bak.Severity != scanner.SeverityLow {
+		t.Errorf("backup.zip severity = %q, want %q (403 hit one step below its configured medium severity)", bak.Severity, scanner.SeverityLow)
+	}
+}
+
+func TestScanSkipsExposureProbesWhenBaselineIsNotNotFound(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		if r.URL.Path == "/" {
+			return
+		}
+		// A soft-404/catch-all server: every path, including the random
+		// baseline probe, answers 200 instead of 404.
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	findings := scanner.Scan(t.Context(), srv.Client(), nil, nil, scanner.PathCheckersFor(true, nil), []string{srv.URL}, 1, nil)
+
+	if len(findings) != 1 {
+		t.Fatalf("Scan() returned %d findings, want exactly 1 (the skip notice): %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Status != scanner.StatusError {
+		t.Errorf("Status = %q, want %q", f.Status, scanner.StatusError)
+	}
+	if f.Message == "" {
+		t.Error("Message is empty, want an explanation of why the check was skipped")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, p := range paths {
+		if p == "/.env" || p == "/.git/config" {
+			t.Errorf("configured path %q was probed, want none of the configured paths probed once the baseline probe is unreliable", p)
+		}
+	}
+	if len(paths) != 2 {
+		t.Errorf("server received %d requests, want 2 (the plain scan request and the baseline probe): %v", len(paths), paths)
+	}
+}
+
+func TestScanExposureProbesAreRootRelativeToTargetOrigin(t *testing.T) {
+	var mu sync.Mutex
+	var sawRootRelativeProbe bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/known.txt" {
+			mu.Lock()
+			sawRootRelativeProbe = true
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	pathCheckers := []scanner.PathChecker{scanner.NewExposureChecker("known.txt", scanner.SeverityMedium)}
+	target := srv.URL + "/app/subdir/"
+	scanner.Scan(t.Context(), srv.Client(), nil, nil, pathCheckers, []string{target}, 1, nil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !sawRootRelativeProbe {
+		t.Error("no probe request for /known.txt observed, want it probed root-relative to the origin regardless of the target URL's own /app/subdir/ path")
+	}
+}
+
+func TestScanExposureBaselineProbePathIsRandomizedPerTarget(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	pathCheckers := []scanner.PathChecker{scanner.NewExposureChecker("known.txt", scanner.SeverityMedium)}
+	known := map[string]bool{"/": true, "/known.txt": true}
+
+	baselinePath := func() string {
+		mu.Lock()
+		paths = nil
+		mu.Unlock()
+		scanner.Scan(t.Context(), srv.Client(), nil, nil, pathCheckers, []string{srv.URL}, 1, nil)
+		mu.Lock()
+		defer mu.Unlock()
+		for _, p := range paths {
+			if !known[p] {
+				return p
+			}
+		}
+		t.Fatal("no baseline probe path observed")
+		return ""
+	}
+
+	first := baselinePath()
+	second := baselinePath()
+	if first == second {
+		t.Errorf("baseline probe path %q repeated across two targets, want a fresh random path each time", first)
+	}
+}
+
+func TestScanExposurePathsAreProbedConcurrently(t *testing.T) {
+	known := map[string]bool{"/a": true, "/b": true, "/c": true}
+	var wg sync.WaitGroup
+	wg.Add(3)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if known[r.URL.Path] {
+			// Blocks until all 3 configured-path probes have arrived: a
+			// prober that issued these sequentially would deadlock here,
+			// since each request waits on its siblings before any of them
+			// gets a response.
+			wg.Done()
+			wg.Wait()
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	pathCheckers := []scanner.PathChecker{
+		scanner.NewExposureChecker("a", scanner.SeverityMedium),
+		scanner.NewExposureChecker("b", scanner.SeverityMedium),
+		scanner.NewExposureChecker("c", scanner.SeverityMedium),
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	findings := scanner.Scan(t.Context(), client, nil, nil, pathCheckers, []string{srv.URL}, 1, nil)
+
+	for _, f := range findings {
+		if f.Status == scanner.StatusError {
+			t.Errorf("unexpected error finding: %+v", f)
+		}
+	}
+}
+
+func TestScanSkipsFailedExposurePathProbeRatherThanErroringTarget(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/known.txt" {
+			<-release
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(func() {
+		close(release)
+		srv.Close()
+	})
+
+	client := &http.Client{Timeout: 50 * time.Millisecond}
+	pathCheckers := []scanner.PathChecker{scanner.NewExposureChecker("known.txt", scanner.SeverityMedium)}
+	findings := scanner.Scan(t.Context(), client, nil, nil, pathCheckers, []string{srv.URL}, 1, nil)
+
+	for _, f := range findings {
+		if f.Status == scanner.StatusError {
+			t.Errorf("got error finding %+v, want the failed path probe skipped rather than erroring the whole target", f)
+		}
+	}
+}
+
+func TestScanExposureExtraPathAloneEnablesCategoryEndToEnd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/debug.log" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	pathCheckers := scanner.PathCheckersFor(false, []string{"debug.log"})
+	findings := scanner.Scan(t.Context(), srv.Client(), nil, nil, pathCheckers, []string{srv.URL}, 1, nil)
+
+	var exposed []scanner.Finding
+	for _, f := range findings {
+		if f.Status == scanner.StatusExposed {
+			exposed = append(exposed, f)
+		}
+	}
+	if len(exposed) != 1 || exposed[0].Header != "debug.log" {
+		t.Fatalf("exposed findings = %+v, want exactly one for the extra path \"debug.log\"", exposed)
 	}
 }

--- a/site/checks/sensitive-path-exposure.md
+++ b/site/checks/sensitive-path-exposure.md
@@ -1,0 +1,42 @@
+---
+layout: page
+title: Sensitive Path Exposure
+permalink: /checks/sensitive-path-exposure
+---
+
+**Severity:** high (`.git/*`, `.env`, `.htpasswd`, `web.config`), medium (`*.bak`/backup archives), low (`.DS_Store`) — one step lower for a `403` hit than the same path's `200`/`206` hit
+
+## What it does
+
+Unlike every other check mamori runs, this one doesn't inspect the response to the target URL itself — it probes each target's origin for well-known sensitive paths (version control metadata, environment files, credential stores, common backup-file patterns) and flags any that turn out to be reachable. That's a meaningfully more intrusive scan than reading headers on the URL the user actually asked for: it issues requests to paths nobody named as a target, with a higher chance of tripping a WAF/IDS and a stronger "is this authorized" question than a passive header read. **It's off by default.**
+
+## Enabling it
+
+Turn the category on with `-check-exposed-paths` (or `MAMORI_CHECK_EXPOSED_PATHS=true`, or `checkExposedPaths: true` in `.mamori.yaml`), which probes the built-in default path list below. `-exposed-path <path>` (repeatable; `exposedPaths:` in the config file, no environment variable equivalent) adds extra paths on top of that list — supplying at least one enables the category on its own, even without `-check-exposed-paths`. User configuration can only extend the default list, never replace or disable any of its entries.
+
+## Default path list
+
+| Path | Severity |
+|---|---|
+| `.git/config` | high |
+| `.git/HEAD` | high |
+| `.env` | high |
+| `.htpasswd` | high |
+| `web.config` | high |
+| `wp-config.php.bak` | medium |
+| `config.php.bak` | medium |
+| `backup.zip` | medium |
+| `backup.tar.gz` | medium |
+| `.DS_Store` | low |
+
+## What mamori checks
+
+For each target with the category enabled, mamori first sends one request to a randomized, deliberately-nonexistent path at the target's origin — fresh per target, so a target can't special-case a fixed probe string. If that doesn't come back `404`, the target is treated as unreliable for this check (e.g. a soft-404/catch-all server that would make every path below look exposed regardless of whether it actually is): mamori reports a single `ERROR` finding noting the check was skipped, and probes none of the configured paths for that target.
+
+Otherwise, every path in the effective list (default plus any extra paths) is probed concurrently, root-relative to the target's scheme+host — regardless of any path component the target URL itself has. For `https://example.com/app/`, that's `https://example.com/.git/config`, not `https://example.com/app/.git/config`.
+
+A `200` or `206` response is a full-severity `EXPOSED` finding: the path is directly readable. A `403` is still a finding — the server treated the path differently from an unrecognized one, so its existence is confirmed — but one severity step down from the same path's `200`/`206` finding, since access is at least blocked. Any other status, in particular `404`, produces no finding at all.
+
+## Further reading
+
+- [OWASP Web Security Testing Guide: Test for Backup and Unreferenced Files or Applications](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/04-Test_for_Backup_and_Unreferenced_Files_or_Applications)

--- a/site/index.md
+++ b/site/index.md
@@ -24,3 +24,4 @@ Each check mamori performs is documented here. Every finding includes a link to 
 | `X-XSS-Protection` | low | [docs](checks/x-xss-protection) |
 | `<script>` / `<link>` (SRI) | low | [docs](checks/subresource-integrity) |
 | Mixed Content | medium | [docs](checks/mixed-content) |
+| Sensitive Path Exposure (opt-in) | high / medium / low | [docs](checks/sensitive-path-exposure) |


### PR DESCRIPTION
## What/why

Adds a new, off-by-default checker category that probes each target's origin for well-known sensitive paths (`.git/config`, `.env`, backups, etc.) and flags any that turn out to be reachable — a `PathChecker` category parallel to the existing header-based `Checker` and body-based `BodyChecker`.

This is meaningfully more intrusive than mamori's existing checks: it issues requests to paths the user never named as a target, raising its own "is this authorized" question (extra requests, higher WAF/IDS-trip risk). Per the issue's design discussion, it ships **opt-in only**.

### Enablement

- `-check-exposed-paths` / `MAMORI_CHECK_EXPOSED_PATHS` / `checkExposedPaths` (flag + env + config-file, same pattern as `-workers`/`-timeout`/`-o`/`-fail-on`) turns the category on with the built-in 10-path default list.
- `-exposed-path` / `exposedPaths` (flag + config-file, no env var, following `-H`'s precedent) adds extra paths on top of the default list — supplying one alone also enables the category, since adding a path can't be a silent no-op. User configuration can only extend the default list, never replace or disable it.

### Request behavior

Before probing any configured path for a target, mamori sends one probe to a randomized, deliberately-nonexistent path at that target's origin (fresh per target). If that doesn't come back `404`, the target is treated as unreliable (a soft-404/catch-all server) and produces a single `error`-status finding instead of probing anything configured. Otherwise every configured path is probed concurrently, root-relative to the target's scheme+host regardless of any path component on the target URL itself.

A `200`/`206` is a full-severity `exposed` finding; `403` is also a finding — the path's existence is confirmed even though access is blocked — but one severity step down from the same path's `200`/`206` finding. `404` (or anything else) produces no finding.

### Key interfaces

- New `PathChecker` interface + `ExposureChecker` implementation (`internal/scanner/exposure.go`), wired into `Scan` the same way `BodyChecker` is — the extra requests only fire when at least one `PathChecker` is configured.
- New `StatusExposed`, kept distinct from `Missing`/`Weak` (those describe header state on the target URL itself, not a separate path's reachability); the soft-404 skip case reuses the existing `StatusError`.
- Findings reuse `Finding.Header` to hold the probed path rather than adding a field — terminal/JSON/SARIF reporters render both kinds through the same field, with only the same kind of extra per-`Status` branch `StatusError` already needed.
- Each default path carries its own fixed severity (high for `.git/*`/`.env`/`.htpasswd`/`web.config`, medium for `*.bak`/backup archives, low for `.DS_Store`); all exposure findings share one OWASP reference link.

## Test evidence

```
$ go build ./... && go vet ./... && golangci-lint run ./...
0 issues.
$ go test ./... -race -count=1
ok  	github.com/PhyberApex/mamori/cmd/mamori	1.030s
ok  	github.com/PhyberApex/mamori/internal/config	1.019s
ok  	github.com/PhyberApex/mamori/internal/scanner	1.326s
```

New tests cover: category disabled is a no-op, a hit at each of `200`/`206`/`403`, a clean `404` path, the soft-404 baseline-skip path (and that it's exactly one finding with no configured paths probed), the baseline path being randomized per target, root-relative probing regardless of the target URL's own path, concurrent per-target probing, a single path's probe failure being skipped rather than erroring the target, extra-path configuration with and without the boolean flag, flag/env/config-file precedence for both settings, and end-to-end coverage in `cmd/mamori` (including `-fail-on` gating on an exposed finding).

Ran `/code-review` against `origin/main` (Standards + Spec axes) and fixed the findings it raised: renamed `DefaultExposurePaths`→`DefaultPathCheckers` and `PathChecker.Check`→`CheckStatus` to match established naming precedent, and corrected doc-comment/CONTEXT.md wording that overstated "no reporter-specific changes."

Closes #53

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*